### PR TITLE
encode viewport into codec and correctly size widget

### DIFF
--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -6,16 +6,16 @@ import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
-  const PictureInfo(this.picture, this.viewBox);
+  const PictureInfo(this.picture, this.size);
 
   /// The picture to be drawn with [ui.canvas.drawPicture]
   final ui.Picture picture;
 
-  /// The target size and position of the picture.
+  /// The target size of the picture.
   ///
   /// This information should be used to scale and position
   /// the picture based on the available space and alignment.
-  final ui.Rect viewBox;
+  final ui.Size size;
 }
 
 /// A listener implementation for the vector graphics codec that converts the
@@ -36,7 +36,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   final List<ui.Path> _paths = <ui.Path>[];
   final List<ui.Shader> _shaders = <ui.Shader>[];
   ui.Path? _currentPath;
-  ui.Rect _viewBox = ui.Rect.zero;
+  ui.Size _size = ui.Size.zero;
   bool _done = false;
 
   static final _emptyPaint = ui.Paint();
@@ -47,7 +47,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   PictureInfo toPicture() {
     assert(!_done);
     _done = true;
-    return PictureInfo(_recorder.endRecording(), _viewBox);
+    return PictureInfo(_recorder.endRecording(), _size);
   }
 
   @override
@@ -220,7 +220,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onViewBox(double minX, double minY, double width, double height) {
-    _viewBox = ui.Rect.fromLTWH(minX, minY, width, height);
+  void onSize(double width, double height) {
+    _size = ui.Size(width, height);
   }
 }

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -50,8 +50,6 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     return PictureInfo(_recorder.endRecording(), _viewBox);
   }
 
-
-
   @override
   void onDrawPath(int pathId, int? paintId) {
     final ui.Path path = _paths[pathId];

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -3,6 +3,21 @@ import 'dart:typed_data';
 
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
+/// The deocded result of a vector graphics asset.
+class PictureInfo {
+  /// Construct a new [PictureInfo].
+  const PictureInfo(this.picture, this.viewBox);
+
+  /// The picture to be drawn with [ui.canvas.drawPicture]
+  final ui.Picture picture;
+
+  /// The target size and position of the picture.
+  ///
+  /// This information should be used to scale and position
+  /// the picture based on the available space and alignment.
+  final ui.Rect viewBox;
+}
+
 /// A listener implementation for the vector graphics codec that converts the
 /// format into a [ui.Picture].
 class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
@@ -21,6 +36,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   final List<ui.Path> _paths = <ui.Path>[];
   final List<ui.Shader> _shaders = <ui.Shader>[];
   ui.Path? _currentPath;
+  ui.Rect _viewBox = ui.Rect.zero;
   bool _done = false;
 
   static final _emptyPaint = ui.Paint();
@@ -28,11 +44,13 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   /// Convert the vector graphics asset this listener decoded into a [ui.Picture].
   ///
   /// This method can only be called once for a given listener instance.
-  ui.Picture toPicture() {
+  PictureInfo toPicture() {
     assert(!_done);
     _done = true;
-    return _recorder.endRecording();
+    return PictureInfo(_recorder.endRecording(), _viewBox);
   }
+
+
 
   @override
   void onDrawPath(int pathId, int? paintId) {
@@ -201,5 +219,10 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       radius,
     );
     _shaders.add(gradient);
+  }
+
+  @override
+  void onViewBox(double minX, double minY, double width, double height) {
+    _viewBox = ui.Rect.fromLTWH(minX, minY, width, height);
   }
 }

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -151,10 +151,6 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
           size: ui.Size(pictureInfo.viewBox.width, pictureInfo.viewBox.height),
           child: _RawVectorGraphicsWidget(
             pictureInfo: pictureInfo,
-            width: widget.width,
-            height: widget.height,
-            alignment: widget.alignment,
-            fit: widget.fit,
           ),
         ),
       ),
@@ -235,17 +231,9 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
   const _RawVectorGraphicsWidget({
     Key? key,
     required this.pictureInfo,
-    required this.width,
-    required this.height,
-    required this.fit,
-    required this.alignment,
   }) : super(key: key);
 
   final PictureInfo pictureInfo;
-  final double? width;
-  final double? height;
-  final BoxFit fit;
-  final AlignmentGeometry alignment;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -255,7 +243,7 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(
       BuildContext context, covariant _RenderVectorGraphics renderObject) {
-    renderObject..pictureInfo = pictureInfo;
+    renderObject.pictureInfo = pictureInfo;
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -15,7 +15,7 @@ const VectorGraphicsCodec _codec = VectorGraphicsCodec();
 /// Decode a vector graphics binary asset into a [ui.Picture].
 ///
 /// Throws a [StateError] if the data is invalid.
-ui.Picture decodeVectorGraphics(ByteData data) {
+PictureInfo decodeVectorGraphics(ByteData data) {
   final FlutterVectorGraphicsListener listener =
       FlutterVectorGraphicsListener();
   _codec.decode(data, listener);
@@ -50,16 +50,59 @@ ui.Picture decodeVectorGraphics(ByteData data) {
 /// }
 /// ```
 class VectorGraphic extends StatefulWidget {
-  const VectorGraphic({Key? key, required this.bytesLoader}) : super(key: key);
+  const VectorGraphic({
+    Key? key,
+    required this.bytesLoader,
+    this.width,
+    this.height,
+    this.fit = BoxFit.contain,
+    this.alignment = Alignment.center,
+  }) : super(key: key);
 
   final BytesLoader bytesLoader;
+
+  /// If specified, the width to use for the vector graphic. If unspecified,
+  /// the vector graphic will take the width of its parent.
+  final double? width;
+
+  /// If specified, the height to use for the vector graphic. If unspecified,
+  /// the vector graphic will take the height of its parent.
+  final double? height;
+
+  /// How to inscribe the picture into the space allocated during layout.
+  /// The default is [BoxFit.contain].
+  final BoxFit fit;
+
+  /// How to align the picture within its parent widget.
+  ///
+  /// The alignment aligns the given position in the picture to the given position
+  /// in the layout bounds. For example, an [Alignment] alignment of (-1.0,
+  /// -1.0) aligns the image to the top-left corner of its layout bounds, while a
+  /// [Alignment] alignment of (1.0, 1.0) aligns the bottom right of the
+  /// picture with the bottom right corner of its layout bounds. Similarly, an
+  /// alignment of (0.0, 1.0) aligns the bottom middle of the image with the
+  /// middle of the bottom edge of its layout bounds.
+  ///
+  /// If the [alignment] is [TextDirection]-dependent (i.e. if it is a
+  /// [AlignmentDirectional]), then a [TextDirection] must be available
+  /// when the picture is painted.
+  ///
+  /// Defaults to [Alignment.center].
+  ///
+  /// See also:
+  ///
+  ///  * [Alignment], a class with convenient constants typically used to
+  ///    specify an [AlignmentGeometry].
+  ///  * [AlignmentDirectional], like [Alignment] for specifying alignments
+  ///    relative to text direction.
+  final AlignmentGeometry alignment;
 
   @override
   State<VectorGraphic> createState() => _VectorGraphicsWidgetState();
 }
 
 class _VectorGraphicsWidgetState extends State<VectorGraphic> {
-  ui.Picture? _picture;
+  PictureInfo? _pictureInfo;
 
   @override
   void initState() {
@@ -77,28 +120,45 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _picture?.dispose();
-    _picture = null;
+    _pictureInfo?.picture.dispose();
+    _pictureInfo = null;
     super.dispose();
   }
 
   void _loadAssetBytes() {
     widget.bytesLoader.loadBytes().then((ByteData data) {
-      final ui.Picture picture = decodeVectorGraphics(data);
+      final PictureInfo pictureInfo = decodeVectorGraphics(data);
       setState(() {
-        _picture?.dispose();
-        _picture = picture;
+        _pictureInfo?.picture.dispose();
+        _pictureInfo = pictureInfo;
       });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final ui.Picture? picture = _picture;
-    if (picture == null) {
-      return const SizedBox();
+    final PictureInfo? pictureInfo = _pictureInfo;
+    if (pictureInfo == null) {
+      return SizedBox(width: widget.width, height: widget.height);
     }
-    return _RawVectorGraphicsWidget(picture: picture);
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: FittedBox(
+        fit: widget.fit,
+        alignment: widget.alignment,
+        child: SizedBox.fromSize(
+          size: ui.Size(pictureInfo.viewBox.width, pictureInfo.viewBox.height),
+          child: _RawVectorGraphicsWidget(
+            pictureInfo: pictureInfo,
+            width: widget.width,
+            height: widget.height,
+            alignment: widget.alignment,
+            fit: widget.fit,
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -172,41 +232,48 @@ class NetworkBytesLoader extends BytesLoader {
 }
 
 class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
-  const _RawVectorGraphicsWidget({Key? key, required this.picture})
-      : super(key: key);
+  const _RawVectorGraphicsWidget({
+    Key? key,
+    required this.pictureInfo,
+    required this.width,
+    required this.height,
+    required this.fit,
+    required this.alignment,
+  }) : super(key: key);
 
-  final ui.Picture picture;
+  final PictureInfo pictureInfo;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final AlignmentGeometry alignment;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderVectorGraphics(picture);
+    return _RenderVectorGraphics(pictureInfo);
   }
 
   @override
   void updateRenderObject(
       BuildContext context, covariant _RenderVectorGraphics renderObject) {
-    renderObject.picture = picture;
+    renderObject..pictureInfo = pictureInfo;
   }
 }
 
 class _RenderVectorGraphics extends RenderProxyBox {
-  _RenderVectorGraphics(this._picture);
+  _RenderVectorGraphics(this._pictureInfo);
 
-  ui.Picture get picture => _picture;
-  ui.Picture _picture;
-  set picture(ui.Picture value) {
-    if (identical(value, _picture)) {
+  PictureInfo get pictureInfo => _pictureInfo;
+  PictureInfo _pictureInfo;
+  set pictureInfo(PictureInfo value) {
+    if (identical(value, _pictureInfo)) {
       return;
     }
-    _picture = value;
+    _pictureInfo = value;
     markNeedsPaint();
   }
 
   @override
   void paint(PaintingContext context, ui.Offset offset) {
-    if (offset != Offset.zero) {
-      context.canvas.translate(offset.dx, offset.dy);
-    }
-    context.canvas.drawPicture(picture);
+    context.canvas.drawPicture(_pictureInfo.picture);
   }
 }

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -148,7 +148,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
         fit: widget.fit,
         alignment: widget.alignment,
         child: SizedBox.fromSize(
-          size: ui.Size(pictureInfo.viewBox.width, pictureInfo.viewBox.height),
+          size: pictureInfo.size,
           child: _RawVectorGraphicsWidget(
             pictureInfo: pictureInfo,
           ),

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_graphics/src/listener.dart';
+import 'package:vector_graphics/vector_graphics.dart';
 
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
@@ -55,4 +57,72 @@ void main() {
 
     expect(listener.toPicture, throwsAssertionError);
   });
+
+  testWidgets('Creates layout widgets when VectorGraphic is sized',
+      (WidgetTester tester) async {
+    final buffer = VectorGraphicsBuffer();
+    await tester.pumpWidget(VectorGraphic(
+      bytesLoader: TestBytesLoader(buffer.done()),
+      width: 100,
+      height: 100,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SizedBox), findsNWidgets(2));
+
+    final SizedBox sizedBox =
+        (find.byType(SizedBox).evaluate().first.widget as SizedBox);
+
+    expect(sizedBox.width, 100);
+    expect(sizedBox.height, 100);
+  });
+
+  testWidgets('Creates alignment widgets when VectorGraphic is aligned',
+      (WidgetTester tester) async {
+    final buffer = VectorGraphicsBuffer();
+    await tester.pumpWidget(VectorGraphic(
+      bytesLoader: TestBytesLoader(buffer.done()),
+      alignment: Alignment.centerLeft,
+      fit: BoxFit.fitHeight,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FittedBox), findsOneWidget);
+
+    final FittedBox fittedBox =
+        (find.byType(FittedBox).evaluate().first.widget as FittedBox);
+
+    expect(fittedBox.fit, BoxFit.fitHeight);
+    expect(fittedBox.alignment, Alignment.centerLeft);
+  });
+
+  testWidgets('Sizes VectorGraphic based on encoded viewbox information',
+      (WidgetTester tester) async {
+    final buffer = VectorGraphicsBuffer();
+    codec.writeViewBox(buffer, 0, 0, 100, 200);
+
+    await tester.pumpWidget(VectorGraphic(
+      bytesLoader: TestBytesLoader(buffer.done()),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SizedBox), findsNWidgets(2));
+
+    final SizedBox sizedBox =
+        (find.byType(SizedBox).evaluate().last.widget as SizedBox);
+
+    expect(sizedBox.width, 100);
+    expect(sizedBox.height, 200);
+  });
+}
+
+class TestBytesLoader extends BytesLoader {
+  TestBytesLoader(this.data);
+
+  final ByteData data;
+
+  @override
+  Future<ByteData> loadBytes() async {
+    return data;
+  }
 }

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -99,7 +99,7 @@ void main() {
   testWidgets('Sizes VectorGraphic based on encoded viewbox information',
       (WidgetTester tester) async {
     final buffer = VectorGraphicsBuffer();
-    codec.writeViewBox(buffer, 0, 0, 100, 200);
+    codec.writeSize(buffer, 100, 200);
 
     await tester.pumpWidget(VectorGraphic(
       bytesLoader: TestBytesLoader(buffer.done()),

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -285,9 +285,7 @@ void main() {
     codec.writeViewBox(buffer, 0, 1, 20, 30);
     codec.decode(buffer.done(), listener);
 
-    expect(listener.commands, [
-      const OnViewBox(0, 1, 20, 30)
-    ]);
+    expect(listener.commands, [const OnViewBox(0, 1, 20, 30)]);
   });
 
   test('Only supports a single viewbox', () {

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -278,21 +278,21 @@ void main() {
     ]);
   });
 
-  test('Encodes a viewbox', () {
+  test('Encodes a size', () {
     final buffer = VectorGraphicsBuffer();
     final TestListener listener = TestListener();
 
-    codec.writeViewBox(buffer, 0, 1, 20, 30);
+    codec.writeSize(buffer, 20, 30);
     codec.decode(buffer.done(), listener);
 
-    expect(listener.commands, [const OnViewBox(0, 1, 20, 30)]);
+    expect(listener.commands, [const OnSize(20, 30)]);
   });
 
-  test('Only supports a single viewbox', () {
+  test('Only supports a single size', () {
     final buffer = VectorGraphicsBuffer();
 
-    codec.writeViewBox(buffer, 0, 1, 20, 30);
-    expect(() => codec.writeViewBox(buffer, 1, 1, 1, 1), throwsStateError);
+    codec.writeSize(buffer, 20, 30);
+    expect(() => codec.writeSize(buffer, 1, 1), throwsStateError);
   });
 }
 
@@ -428,8 +428,8 @@ class TestListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onViewBox(double minX, double minY, double width, double height) {
-    commands.add(OnViewBox(minX, minY, width, height));
+  void onSize(double width, double height) {
+    commands.add(OnSize(width, height));
   }
 }
 
@@ -735,27 +735,21 @@ class OnPathStart {
   String toString() => 'OnPathStart($id, $fillType)';
 }
 
-class OnViewBox {
-  const OnViewBox(this.minX, this.minY, this.width, this.height);
+class OnSize {
+  const OnSize(this.width, this.height);
 
-  final double minX;
-  final double minY;
   final double width;
   final double height;
 
   @override
-  int get hashCode => Object.hash(minX, minY, width, height);
+  int get hashCode => Object.hash(width, height);
 
   @override
   bool operator ==(Object other) =>
-      other is OnViewBox &&
-      other.minX == minX &&
-      other.minY == minY &&
-      other.width == width &&
-      other.height == height;
+      other is OnSize && other.width == width && other.height == height;
 
   @override
-  String toString() => 'OnViewBox($minX, $minY, $width, $height)';
+  String toString() => 'OnSize($width, $height)';
 }
 
 bool _listEquals<E>(List<E>? left, List<E>? right) {

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -277,6 +277,25 @@ void main() {
       ),
     ]);
   });
+
+  test('Encodes a viewbox', () {
+    final buffer = VectorGraphicsBuffer();
+    final TestListener listener = TestListener();
+
+    codec.writeViewBox(buffer, 0, 1, 20, 30);
+    codec.decode(buffer.done(), listener);
+
+    expect(listener.commands, [
+      const OnViewBox(0, 1, 20, 30)
+    ]);
+  });
+
+  test('Only supports a single viewbox', () {
+    final buffer = VectorGraphicsBuffer();
+
+    codec.writeViewBox(buffer, 0, 1, 20, 30);
+    expect(() => codec.writeViewBox(buffer, 1, 1, 1, 1), throwsStateError);
+  });
 }
 
 class TestListener extends VectorGraphicsCodecListener {
@@ -408,6 +427,11 @@ class TestListener extends VectorGraphicsCodecListener {
       tileMode: tileMode,
       id: id,
     ));
+  }
+
+  @override
+  void onViewBox(double minX, double minY, double width, double height) {
+    commands.add(OnViewBox(minX, minY, width, height));
   }
 }
 
@@ -711,6 +735,29 @@ class OnPathStart {
 
   @override
   String toString() => 'OnPathStart($id, $fillType)';
+}
+
+class OnViewBox {
+  const OnViewBox(this.minX, this.minY, this.width, this.height);
+
+  final double minX;
+  final double minY;
+  final double width;
+  final double height;
+
+  @override
+  int get hashCode => Object.hash(minX, minY, width, height);
+
+  @override
+  bool operator ==(Object other) =>
+      other is OnViewBox &&
+      other.minX == minX &&
+      other.minY == minY &&
+      other.width == width &&
+      other.height == height;
+
+  @override
+  String toString() => 'OnViewBox($minX, $minY, $width, $height)';
 }
 
 bool _listEquals<E>(List<E>? left, List<E>? right) {

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -36,6 +36,8 @@ Future<Uint8List> encodeSVG(String input, String filename) async {
   final VectorInstructions instructions = await parse(input, key: filename);
   final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
 
+  codec.writeViewBox(buffer, 0, 0, instructions.width, instructions.height);
+
   final Map<int, int> fillIds = <int, int>{};
   final Map<int, int> strokeIds = <int, int>{};
   final Map<Shader, int> shaderIds = <Shader, int>{};

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -36,7 +36,7 @@ Future<Uint8List> encodeSVG(String input, String filename) async {
   final VectorInstructions instructions = await parse(input, key: filename);
   final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
 
-  codec.writeViewBox(buffer, 0, 0, instructions.width, instructions.height);
+  codec.writeSize(buffer, instructions.width, instructions.height);
 
   final Map<int, int> fillIds = <int, int>{};
   final Map<int, int> strokeIds = <int, int>{};


### PR DESCRIPTION
Begins encoding the svg viewbox into the binary format. Also implements runtime sizing based on the same strategy as flutter_svg