### PR TITLE
Fix RRect parsing, make PathBuilder chainable

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/geometry/path.dart
+++ b/packages/vector_graphics_compiler/lib/src/geometry/path.dart
@@ -251,13 +251,14 @@ class PathBuilder implements PathProxy {
   Point _currentPoint = Point.zero;
 
   @override
-  void close() {
+  PathBuilder close() {
     _commands.add(const CloseCommand());
     _currentPoint = _currentSubPathPoint;
+    return this;
   }
 
   @override
-  void cubicTo(
+  PathBuilder cubicTo(
     double x1,
     double y1,
     double x2,
@@ -267,27 +268,31 @@ class PathBuilder implements PathProxy {
   ) {
     _commands.add(CubicToCommand(x1, y1, x2, y2, x3, y3));
     _currentPoint = Point(x3, y3);
+    return this;
   }
 
   @override
-  void lineTo(double x, double y) {
+  PathBuilder lineTo(double x, double y) {
     _commands.add(LineToCommand(x, y));
     _currentPoint = Point(x, y);
+    return this;
   }
 
   @override
-  void moveTo(double x, double y) {
+  PathBuilder moveTo(double x, double y) {
     _commands.add(MoveToCommand(x, y));
     _currentPoint = _currentSubPathPoint = Point(x, y);
+    return this;
   }
 
   /// Adds the commands of an existing path to the new path being created.
-  void addPath(Path other) {
+  PathBuilder addPath(Path other) {
     _commands.addAll(other._commands);
+    return this;
   }
 
   /// Adds an oval command to new path.
-  void addOval(Rect oval) {
+  PathBuilder addOval(Rect oval) {
     final Point r = Point(oval.width * 0.5, oval.height * 0.5);
     final Point c = Point(
       oval.left + (oval.width * 0.5),
@@ -313,22 +318,23 @@ class PathBuilder implements PathProxy {
     cubicTo(c.x - r.x, c.y - m.y, c.x - m.x, c.y - r.y, c.x, c.y - r.y);
 
     close();
+    return this;
   }
 
   /// Adds a rectangle to the new path.
-  void addRect(Rect rect) {
+  PathBuilder addRect(Rect rect) {
     moveTo(rect.right, rect.top);
     lineTo(rect.right, rect.bottom);
     lineTo(rect.left, rect.bottom);
     lineTo(rect.left, rect.top);
     close();
+    return this;
   }
 
   /// Adds a rounded rectangle to the new path.
-  void addRRect(Rect rect, double rx, double ry) {
+  PathBuilder addRRect(Rect rect, double rx, double ry) {
     if (rx == 0 && ry == 0) {
-      addRect(rect);
-      return;
+      return addRect(rect);
     }
 
     final Point magicRadius = Point(rx, ry) * _kArcApproximationMagic;
@@ -388,6 +394,7 @@ class PathBuilder implements PathProxy {
     );
 
     close();
+    return this;
   }
 
   /// The fill type to use for the new path.

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -665,7 +665,7 @@ class _Paths {
       parserState.attribute('r', def: '0'),
     )!;
     final Rect oval = Rect.fromCircle(cx, cy, r);
-    return (PathBuilder()..addOval(oval)).toPath();
+    return PathBuilder().addOval(oval).toPath();
   }
 
   static Path path(SvgParser parserState) {
@@ -694,13 +694,10 @@ class _Paths {
     if (rxRaw != null && rxRaw != '') {
       final double rx = parserState.parseDoubleWithUnits(rxRaw)!;
       final double ry = parserState.parseDoubleWithUnits(ryRaw)!;
-
-      return (PathBuilder()
-            ..addRRect(Rect.fromLTRB(x, y, w - x, h - y), rx, ry))
-          .toPath();
+      return PathBuilder().addRRect(Rect.fromLTWH(x, y, w, h), rx, ry).toPath();
     }
 
-    return (PathBuilder()..addRect(Rect.fromLTWH(x, y, w, h))).toPath();
+    return PathBuilder().addRect(Rect.fromLTWH(x, y, w, h)).toPath();
   }
 
   static Path? polygon(SvgParser parserState) {
@@ -736,7 +733,7 @@ class _Paths {
     )!;
 
     final Rect r = Rect.fromLTWH(cx - rx, cy - ry, rx * 2, ry * 2);
-    return (PathBuilder()..addOval(r)).toPath();
+    return PathBuilder().addOval(r).toPath();
   }
 
   static Path line(SvgParser parserState) {
@@ -753,10 +750,7 @@ class _Paths {
       parserState.attribute('y2', def: '0'),
     )!;
 
-    return (PathBuilder()
-          ..moveTo(x1, y1)
-          ..lineTo(x2, y2))
-        .toPath();
+    return PathBuilder().moveTo(x1, y1).lineTo(x2, y2).toPath();
   }
 }
 

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -5,6 +5,20 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Parses rrects correctly', () async {
+    const String svg = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect x="11" y="36" width="31" height="20" rx="2.5" fill="red" />
+</svg>
+''';
+    final VectorInstructions instructions = await parse(svg);
+    expect(instructions.paths, <Path>[
+      PathBuilder()
+          .addRRect(const Rect.fromLTWH(11, 36, 31, 20), 2.5, 2.5)
+          .toPath()
+    ]);
+  });
+
   test('Combines clips where possible', () async {
     const String svg = '''
 <!-- Learn about this code on MDN: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath -->
@@ -22,11 +36,11 @@ void main() {
 ''';
     final VectorInstructions instructions = await parse(svg);
     expect(instructions.paths, <Path>[
-      (PathBuilder()
-            ..addOval(const Rect.fromCircle(30, 30, 20))
-            ..addOval(const Rect.fromCircle(70, 70, 20)))
+      PathBuilder()
+          .addOval(const Rect.fromCircle(30, 30, 20))
+          .addOval(const Rect.fromCircle(70, 70, 20))
           .toPath(),
-      (PathBuilder()..addRect(const Rect.fromLTWH(10, 10, 100, 100))).toPath(),
+      PathBuilder().addRect(const Rect.fromLTWH(10, 10, 100, 100)).toPath(),
     ]);
     expect(instructions.commands, const <DrawCommand>[
       DrawCommand(0, -1, DrawCommandType.clip, null),
@@ -55,10 +69,10 @@ void main() {
     expect(instructions.paths, <Path>[
       parseSvgPathData(
           'M 250,75 L 323,301 131,161 369,161 177,301 z', PathFillType.evenOdd),
-      (PathBuilder()..addOval(const Rect.fromCircle(400, 200, 150))).toPath(),
+      PathBuilder().addOval(const Rect.fromCircle(400, 200, 150)).toPath(),
       parseSvgPathData('M 250,75 L 323,301 131,161 369,161 177,301 z')
           .transformed(AffineMatrix.identity.translated(250, 0)),
-      (PathBuilder()..addOval(const Rect.fromCircle(450, 300, 150))).toPath(),
+      PathBuilder().addOval(const Rect.fromCircle(450, 300, 150)).toPath(),
     ]);
     expect(instructions.commands, const <DrawCommand>[
       DrawCommand(0, -1, DrawCommandType.clip, null),


### PR DESCRIPTION
I don't know why I didn't just use `Rect.fromLTWH`, maybe hadn't written it yet? Either way I was subtracting instead of adding oops.

I also got tired of writing tests and code that looked like `(PathBuilder()..addSomething()..addAnotherThing()..close()).toPath()` so I made it where you can write `PathBuilder().addSomething().addAnotherThing().close().toPath()`.