### PR TITLE
Fix gradient regressions, OoO support for use/gradients

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
@@ -105,7 +105,7 @@ AffineMatrix _parseSvgRotate(String? paramsStr, AffineMatrix current) {
     return AffineMatrix(1.0, 0.0, 0.0, 1.0, x, y)
         .multiplied(current)
         .multiplied(rotate)
-        .multiplied(AffineMatrix(1.0, 0.0, 0.0, 1.0, -x, -y));
+        .translated(-x, -y);
   } else {
     return rotate.multiplied(current);
   }

--- a/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
+++ b/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
@@ -10,13 +10,14 @@ class VectorInstructions {
   /// Creates a new set of [VectorInstructions].
   ///
   /// The combined lengths of [paths] and [vertices] must be greater than 0.
-  const VectorInstructions(
-      {required this.width,
-      required this.height,
-      required this.paints,
-      this.paths = const <Path>[],
-      this.vertices = const <IndexedVertices>[],
-      required this.commands});
+  const VectorInstructions({
+    required this.width,
+    required this.height,
+    required this.paints,
+    this.paths = const <Path>[],
+    this.vertices = const <IndexedVertices>[],
+    required this.commands,
+  });
 
   /// The extent of the viewport on the x axis.
   final double width;

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -63,9 +63,9 @@ Future<Uint8List> encodeSvg(String input, String filename) async {
         toX: shader.to.x,
         toY: shader.to.y,
         colors: Int32List.fromList(
-            <int>[for (Color color in shader.colors) color.value]),
-        offsets: Float32List.fromList(shader.offsets),
-        tileMode: shader.tileMode.index,
+            <int>[for (Color color in shader.colors!) color.value]),
+        offsets: Float32List.fromList(shader.offsets!),
+        tileMode: shader.tileMode!.index,
       );
     } else if (shader is RadialGradient) {
       shaderId = codec.writeRadialGradient(
@@ -76,9 +76,9 @@ Future<Uint8List> encodeSvg(String input, String filename) async {
         focalX: shader.focalPoint?.x,
         focalY: shader.focalPoint?.y,
         colors: Int32List.fromList(
-            <int>[for (Color color in shader.colors) color.value]),
-        offsets: Float32List.fromList(shader.offsets),
-        tileMode: shader.tileMode.index,
+            <int>[for (Color color in shader.colors!) color.value]),
+        offsets: Float32List.fromList(shader.offsets!),
+        tileMode: shader.tileMode!.index,
         transform: _encodeMatrix(shader.transform),
       );
     } else {

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -47,10 +47,10 @@ Future<Uint8List> encodeSvg(String input, String filename) async {
 
   final Map<int, int> fillIds = <int, int>{};
   final Map<int, int> strokeIds = <int, int>{};
-  final Map<Shader, int> shaderIds = <Shader, int>{};
+  final Map<Gradient, int> shaderIds = <Gradient, int>{};
 
   for (final Paint paint in instructions.paints) {
-    final Shader? shader = paint.fill?.shader;
+    final Gradient? shader = paint.fill?.shader;
     if (shader == null) {
       continue;
     }

--- a/packages/vector_graphics_compiler/test/paint_test.dart
+++ b/packages/vector_graphics_compiler/test/paint_test.dart
@@ -20,90 +20,9 @@ void main() {
     expect(testColor.b, 0xEF);
   });
 
-  test('Paint toFlutterString', () {
-    const Paint paint = Paint(
-      blendMode: BlendMode.screen,
-      stroke: Stroke(
-          color: Color(0x87654321),
-          width: 2.0,
-          cap: StrokeCap.round,
-          join: StrokeJoin.bevel,
-          miterLimit: 10.0,
-          shader: LinearGradient(
-            from: Point(0, 0),
-            to: Point(10, 10),
-            colors: <Color>[Color.opaqueBlack, Color(0xFFABCDEF)],
-            tileMode: TileMode.mirror,
-            offsets: <double>[0.0, 1.0],
-            transform: AffineMatrix.identity,
-            unitMode: GradientUnitMode.userSpaceOnUse,
-          )),
-      fill: Fill(
-        color: Color(0x12345678),
-        shader: RadialGradient(
-          center: Point(50, 50),
-          radius: 10,
-          colors: <Color>[Color(0xFFFFFFAA), Color(0xFFABCDEF)],
-          tileMode: TileMode.clamp,
-          transform: AffineMatrix.identity,
-          focalPoint: Point(5, 50),
-          offsets: <double>[.1, .9],
-        ),
-      ),
-    );
-
-    expect(
-      paint.fill!.toFlutterPaintString(
-        'shader1',
-        'fillPaint',
-        paint.blendMode,
-      ),
-      'final shader1 = Gradient.radial(\n'
-      '  const Offset(50.0, 50.0),\n'
-      '  10.0,\n'
-      '  [Color(0xffffffaa), Color(0xffabcdef)],\n'
-      '  [0.1, 0.9],\n'
-      '  TileMode.clamp,\n'
-      '  Float64List.fromList(<double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),\n'
-      '  const Offset(5.0, 50.0),\n'
-      '  0.0,\n'
-      ');\n'
-      '\n'
-      'final fillPaint = Paint()\n'
-      '  ..blendMode = BlendMode.screen\n'
-      '  ..color = Color(0x12345678)\n'
-      '  ..shader = shader1;\n',
-    );
-
-    expect(
-      paint.stroke!.toFlutterPaintString(
-        'shader2',
-        'strokePaint',
-        paint.blendMode,
-      ),
-      'final shader2 = Gradient.linear(\n'
-      '  const Offset(0.0, 0.0),\n'
-      '  const Offset(10.0, 10.0),\n'
-      '  [Color(0xff000000), Color(0xffabcdef)],\n'
-      '  [0.0, 1.0],\n'
-      '  TileMode.mirror,\n'
-      '  Float64List.fromList([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),\n'
-      ');\n'
-      '\n'
-      'final strokePaint = Paint()\n'
-      '  ..blendMode = BlendMode.screen\n'
-      '  ..color = Color(0x87654321)\n'
-      '  ..shader = shader2\n'
-      '  ..strokeCap = StrokeCap.round\n'
-      '  ..strokeJoin = StrokeJoin.bevel\n'
-      '  ..strokeMiterLimit = 10.0\n'
-      '  ..strokeWidth = 2.0\n'
-      '  ..style = PaintingStyle.stroke;\n',
-    );
-  });
-
   test('LinearGradient can be converted to local coordinates', () {
     const LinearGradient gradient = LinearGradient(
+      id: 'test',
       from: Point(0, 0),
       to: Point(1, 1),
       colors: <Color>[Color.opaqueBlack, Color(0xFFABCDEF)],
@@ -123,6 +42,7 @@ void main() {
 
   test('LinearGradient applied bounds with userSpaceOnUse', () {
     const LinearGradient gradient = LinearGradient(
+      id: 'test',
       from: Point(0, 0),
       to: Point(1, 1),
       colors: <Color>[Color.opaqueBlack, Color(0xFFABCDEF)],
@@ -143,6 +63,7 @@ void main() {
 
   test('LinearGradient applied bounds with userSpaceOnUse and transformed', () {
     final LinearGradient gradient = LinearGradient(
+      id: 'test',
       from: const Point(0, 0),
       to: const Point(1, 1),
       colors: const <Color>[Color.opaqueBlack, Color(0xFFABCDEF)],
@@ -163,6 +84,7 @@ void main() {
 
   test('RadialGradient can be converted to local coordinates', () {
     const RadialGradient gradient = RadialGradient(
+      id: 'test',
       center: Point(0.5, 0.5),
       radius: 10,
       colors: <Color>[Color(0xFFFFFFAA), Color(0xFFABCDEF)],
@@ -183,6 +105,7 @@ void main() {
 
   test('RadialGradient applied bounds with userSpaceOnUse', () {
     const RadialGradient gradient = RadialGradient(
+      id: 'test',
       center: Point(0.5, 0.5),
       radius: 10,
       colors: <Color>[Color(0xFFFFFFAA), Color(0xFFABCDEF)],

--- a/packages/vector_graphics_compiler/test/paint_test.dart
+++ b/packages/vector_graphics_compiler/test/paint_test.dart
@@ -113,7 +113,9 @@ void main() {
     );
 
     final LinearGradient transformed = gradient.applyBounds(
-        const Rect.fromLTWH(5, 5, 100, 100), AffineMatrix.identity);
+      const Rect.fromLTWH(5, 5, 100, 100),
+      AffineMatrix.identity,
+    );
 
     expect(transformed.from, const Point(5, 5));
     expect(transformed.to, const Point(105, 105));
@@ -131,7 +133,9 @@ void main() {
     );
 
     final LinearGradient transformed = gradient.applyBounds(
-        const Rect.fromLTWH(5, 5, 100, 100), AffineMatrix.identity);
+      const Rect.fromLTWH(5, 5, 100, 100),
+      AffineMatrix.identity,
+    );
 
     expect(transformed.from, const Point(0, 0));
     expect(transformed.to, const Point(1, 1));
@@ -149,7 +153,9 @@ void main() {
     );
 
     final LinearGradient transformed = gradient.applyBounds(
-        const Rect.fromLTWH(5, 5, 100, 100), AffineMatrix.identity);
+      const Rect.fromLTWH(5, 5, 100, 100),
+      AffineMatrix.identity,
+    );
 
     expect(transformed.from, const Point(0, 0));
     expect(transformed.to, const Point(2, 2));
@@ -167,7 +173,9 @@ void main() {
     );
 
     final RadialGradient transformed = gradient.applyBounds(
-        const Rect.fromLTWH(5, 5, 100, 100), AffineMatrix.identity);
+      const Rect.fromLTWH(5, 5, 100, 100),
+      AffineMatrix.identity.translated(5, 5).scaled(100, 100),
+    );
 
     expect(transformed.center, const Point(55, 55));
     expect(transformed.focalPoint, const Point(65, 65));
@@ -186,7 +194,9 @@ void main() {
     );
 
     final RadialGradient transformed = gradient.applyBounds(
-        const Rect.fromLTWH(5, 5, 100, 100), AffineMatrix.identity);
+      const Rect.fromLTWH(5, 5, 100, 100),
+      AffineMatrix.identity,
+    );
 
     expect(transformed.center, const Point(0.5, 0.5));
     expect(transformed.focalPoint, const Point(0.6, 0.6));

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -5,6 +5,55 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('gradients can handle inheriting unit mode', () async {
+    final VectorInstructions instructions =
+        await parse(linearGradientThatInheritsUnitMode);
+    expect(instructions.paints, const <Paint>[
+      Paint(
+        fill: Fill(
+          color: Color(0xffffffff),
+          shader: LinearGradient(
+            id: 'url(#a)',
+            from: Point(236.702, 9.99),
+            to: Point(337.966, 241.771),
+            colors: <Color>[
+              Color(0xffffffff),
+              Color(0xb9c2c3c3),
+              Color(0x6a7d7e80),
+              Color(0x314b4c4e),
+              Color(0x0d2c2d30),
+              Color(0x00202124)
+            ],
+            offsets: <double>[0.0, 0.229, 0.508, 0.739, 0.909, 1.0],
+            tileMode: TileMode.clamp,
+            unitMode: GradientUnitMode.transformed,
+          ),
+        ),
+      ),
+      Paint(
+        fill: Fill(
+          color: Color(0xffffffff),
+          shader: LinearGradient(
+            id: 'url(#d)',
+            from: Point(0.0, 50.243),
+            to: Point(0.0, 330.779),
+            colors: <Color>[
+              Color(0xffffffff),
+              Color(0xb9c2c3c3),
+              Color(0x6a7d7e80),
+              Color(0x314b4c4e),
+              Color(0x0d2c2d30),
+              Color(0x00202124)
+            ],
+            offsets: <double>[0.0, 0.229, 0.508, 0.739, 0.909, 1.0],
+            tileMode: TileMode.clamp,
+            unitMode: GradientUnitMode.transformed,
+          ),
+        ),
+      )
+    ]);
+  });
+
   test('group opacity results in save layer', () async {
     final VectorInstructions instructions = await parse(groupOpacity);
     expect(instructions.paths, <Path>[
@@ -58,6 +107,7 @@ void main() {
         fill: Fill(
           color: Color(0xffffffff),
           shader: LinearGradient(
+            id: 'url(#b)',
             from: Point(0.000763280000001032, 47.19967163999999),
             to: Point(94.40007452, 47.19967163999999),
             colors: <Color>[Color(0xff0f12cb), Color(0xfffded3a)],
@@ -85,6 +135,7 @@ void main() {
         fill: Fill(
           color: Color(0xffffffff),
           shader: LinearGradient(
+            id: 'url(#paint0_linear)',
             from: Point(10.0, 0.0),
             to: Point(10.0, 19.852),
             colors: <Color>[Color(0xff0000ff), Color(0xffffff00)],
@@ -112,6 +163,7 @@ void main() {
     );
 
     const LinearGradient gradient1 = LinearGradient(
+      id: 'url(#linearGradient-3)',
       from: Point(46.9782516, 60.9121966),
       to: Point(60.42279469999999, 90.6839734),
       colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
@@ -120,6 +172,7 @@ void main() {
       unitMode: GradientUnitMode.transformed,
     );
     const LinearGradient gradient2 = LinearGradient(
+      id: 'url(#linearGradient-3)',
       from: Point(47.58260128, 58.72975728),
       to: Point(58.338235759999996, 82.54717871999999),
       colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -28,8 +28,20 @@ void main() {
     final VectorInstructions instructions = await parse(xlinkGradient);
     final VectorInstructions instructions2 = await parse(xlinkGradientOoO);
 
-    expect(instructions, instructions2);
-  }, skip: true); // Does not work yet.
+    expect(instructions.paints, instructions2.paints);
+    expect(instructions.paths, instructions2.paths);
+    expect(instructions.commands, instructions2.commands);
+  });
+
+  test('xlink use Out of order', () async {
+    final VectorInstructions instructions = await parse(simpleUseCircles);
+    final VectorInstructions instructions2 = await parse(simpleUseCirclesOoO);
+
+    // Use toSet to ignore ordering differences.
+    expect(instructions.paints.toSet(), instructions2.paints.toSet());
+    expect(instructions.paths.toSet(), instructions2.paths.toSet());
+    expect(instructions.commands.toSet(), instructions2.commands.toSet());
+  });
 
   test('xlink gradient with transform', () async {
     final VectorInstructions instructions = await parse(xlinkGradient);
@@ -51,7 +63,7 @@ void main() {
             colors: <Color>[Color(0xff0f12cb), Color(0xfffded3a)],
             offsets: <double>[0.0, 1.0],
             tileMode: TileMode.clamp,
-            unitMode: GradientUnitMode.userSpaceOnUse,
+            unitMode: GradientUnitMode.transformed,
           ),
         ),
       )
@@ -78,7 +90,7 @@ void main() {
             colors: <Color>[Color(0xff0000ff), Color(0xffffff00)],
             offsets: <double>[0.0, 1.0],
             tileMode: TileMode.clamp,
-            unitMode: GradientUnitMode.userSpaceOnUse,
+            unitMode: GradientUnitMode.transformed,
           ),
         ),
       )
@@ -105,7 +117,7 @@ void main() {
       colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
       offsets: <double>[0.0, 1.0],
       tileMode: TileMode.clamp,
-      unitMode: GradientUnitMode.userSpaceOnUse,
+      unitMode: GradientUnitMode.transformed,
     );
     const LinearGradient gradient2 = LinearGradient(
       from: Point(47.58260128, 58.72975728),
@@ -113,7 +125,7 @@ void main() {
       colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
       offsets: <double>[0.0, 1.0],
       tileMode: TileMode.clamp,
-      unitMode: GradientUnitMode.userSpaceOnUse,
+      unitMode: GradientUnitMode.transformed,
     );
     expect(instructions.paints, const <Paint>[
       Paint(fill: Fill(color: Color(0xffadd8e6))),

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -839,6 +839,15 @@ const String simpleUseCircles = '''
 </svg>
 ''';
 
+const String simpleUseCirclesOoO = '''
+<svg viewBox="0 0 30 10"
+    xmlns="http://www.w3.org/2000/svg">
+    <use href="#myCircle" x="20" fill="white" stroke="blue"/>
+    <circle id="myCircle" cx="5" cy="5" r="4"/>
+    <use href="#myCircle" x="10" fill="blue"/>
+</svg>
+''';
+
 /// https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
 const String basicText = '''
 <svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -912,3 +912,21 @@ const String xlinkGradientOoO = '''
   <circle cx="-83.533" cy="122.753" r="74.461" fill="url(#b)" transform="matrix(.63388 0 0 .63388 100.15 -30.611)"/>
 </svg>
 ''';
+
+const String linearGradientThatInheritsUnitMode = '''
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 412 412">
+  <defs>
+    <linearGradient id="a" x1="236.702" y1="9.99" x2="337.966" y2="241.771" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff" />
+      <stop offset=".229" stop-color="#c2c3c3" stop-opacity=".728" />
+      <stop offset=".508" stop-color="#7d7e80" stop-opacity=".419" />
+      <stop offset=".739" stop-color="#4b4c4e" stop-opacity=".193" />
+      <stop offset=".909" stop-color="#2c2d30" stop-opacity=".053" />
+      <stop offset="1" stop-color="#202124" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="d" x1="0" y1="50.243" x2="0" y2="330.779" xlink:href="#a" />
+  </defs>
+  <path d="M216.091 211.2H412v-84.88h-23.56" fill="url(#a)" />
+  <path d="M412 256.565v155.9h-824v-99.456l334.7-90.165a677.363 677.363 0 01183.33-23.69c35.17.36 73.37 3.551 110.06 12.051z" fill="url(#d)" />
+</svg>
+''';


### PR DESCRIPTION
- Defer resolution to build and assert resolution doesn't happen during parsing.
- Fix regressions introduced in the last commit around userSpaceOnUse with transforms
  for linear gradients, and regressions around radial gradients in general.
- Tests

Things that are still wrong:

- I noticed while working on flutter_svg's "devil" SVG test that blends are not
  being accurately applied to individual paths. I'll try to address that
  in a separate PR.
- userSpaceOnUse gradients with transforms are not being applied correctly. This
  has been an issue in this repo forever, not a regression. Gotta figure out how
  to properly transform the gradient to the transformed path coordinate space.
  See https://github.com/dnfield/flutter_svg/pull/54/files#r216222991 and the
  test files added in that PR, which do not compile correctly today.