### PR TITLE
Make sure that the loadBytes method gets called when dependencies change, add tests, make it easier use context from loaders while still being const

### DIFF
--- a/packages/vector_graphics/analysis_options.yaml
+++ b/packages/vector_graphics/analysis_options.yaml
@@ -1,4 +1,33 @@
 include: package:flutter_lints/flutter.yaml
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  language:
+    strict-raw-types: true
+  strong-mode:
+    implicit-casts: false
+  errors:
+    missing_required_param: error
+    todo: ignore
+
+linter:
+
+  rules:
+    always_declare_return_types: true
+    always_put_control_body_on_new_line: true
+    always_specify_types: true
+    avoid_dynamic_calls: true
+    avoid_redundant_argument_values: true
+    avoid_print: false  # For now, the compiler is printing.
+    prefer_single_quotes: true
+    # flutter_style_todos: true TODO(dnfield): enable this eventually
+    hash_and_equals: true
+    no_default_cases: true
+    only_throw_errors: true
+    prefer_final_fields: true
+    prefer_final_locals: true
+    public_member_api_docs: true
+    recursive_getters: true
+    sort_constructors_first: true
+    sort_unnamed_constructors_first: true
+    test_types_in_equals: true
+    unnecessary_late: true

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
           child: ListView(
             children: const <Widget>[
               VectorGraphic(
-                loader: AssetBytesLoader(assetName: 'assets/tiger.bin'),
+                loader: AssetBytesLoader('assets/tiger.bin'),
               ),
               VectorGraphic(
                 loader: NetworkSvgLoader(

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:vector_graphics/vector_graphics.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 
@@ -25,13 +24,12 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         body: Center(
           child: ListView(
-            children: <Widget>[
+            children: const <Widget>[
               VectorGraphic(
-                bytesLoader: AssetBytesLoader(
-                    assetName: 'assets/tiger.bin', assetBundle: rootBundle),
+                loader: AssetBytesLoader(assetName: 'assets/tiger.bin'),
               ),
-              const VectorGraphic(
-                bytesLoader: NetworkSvgLoader(
+              VectorGraphic(
+                loader: NetworkSvgLoader(
                   'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
                 ),
               )
@@ -49,7 +47,7 @@ class NetworkSvgLoader extends BytesLoader {
   final String url;
 
   @override
-  Future<ByteData> loadBytes() async {
+  Future<ByteData> loadBytes(BuildContext context) async {
     return await compute((String svgUrl) async {
       final http.Response request = await http.get(Uri.parse(svgUrl));
       // print('Got respone for $svgUrl: (${request.statusCode}) ${request.contentLength} bytes');
@@ -59,5 +57,13 @@ class NetworkSvgLoader extends BytesLoader {
       // sendAndExit will make sure this isn't copied.
       return compiledBytes.buffer.asByteData();
     }, url, debugLabel: 'Load Bytes');
+  }
+
+  @override
+  int get hashCode => url.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is NetworkSvgLoader && other.url == url;
   }
 }

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -39,8 +39,8 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   ui.Size _size = ui.Size.zero;
   bool _done = false;
 
-  static final _emptyPaint = ui.Paint();
-  static final _grayscaleDstInPaint = ui.Paint()
+  static final ui.Paint _emptyPaint = ui.Paint();
+  static final ui.Paint _grayscaleDstInPaint = ui.Paint()
     ..blendMode = ui.BlendMode.dstIn
     ..colorFilter = const ui.ColorFilter.matrix(<double>[
       0, 0, 0, 0, 0, //
@@ -236,7 +236,6 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       ui.TileMode.values[tileMode],
       transform,
       hasFocal ? focal : null,
-      0,
     );
     _shaders.add(gradient);
   }

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -53,14 +53,19 @@ PictureInfo decodeVectorGraphics(ByteData data) {
 class VectorGraphic extends StatefulWidget {
   const VectorGraphic({
     Key? key,
-    required this.bytesLoader,
+    required this.loader,
     this.width,
     this.height,
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
   }) : super(key: key);
 
-  final BytesLoader bytesLoader;
+  /// A delegate for fetching the raw bytes of the vector graphic.
+  ///
+  /// The [BytesLoader.loadBytes] method will be called with this
+  /// widget's [BuildContext] whenever dependencies change or the widget
+  /// configuration changes the loader.
+  final BytesLoader loader;
 
   /// If specified, the width to use for the vector graphic. If unspecified,
   /// the vector graphic will take the width of its parent.
@@ -106,14 +111,14 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
   PictureInfo? _pictureInfo;
 
   @override
-  void initState() {
+  void didChangeDependencies() {
     _loadAssetBytes();
-    super.initState();
+    super.didChangeDependencies();
   }
 
   @override
   void didUpdateWidget(covariant VectorGraphic oldWidget) {
-    if (oldWidget.bytesLoader != widget.bytesLoader) {
+    if (oldWidget.loader != widget.loader) {
       _loadAssetBytes();
     }
     super.didUpdateWidget(oldWidget);
@@ -127,7 +132,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
   }
 
   void _loadAssetBytes() {
-    widget.bytesLoader.loadBytes().then((ByteData data) {
+    widget.loader.loadBytes(context).then((ByteData data) {
       final PictureInfo pictureInfo = decodeVectorGraphics(data);
       setState(() {
         _pictureInfo?.picture.dispose();
@@ -169,37 +174,47 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 /// See also:
 ///   * [AssetBytesLoader], for loading from the asset bundle.
 ///   * [NetworkBytesLoader], for loading network bytes.
+@immutable
 abstract class BytesLoader {
-  /// const constructor to allow subtypes to be const.
+  /// Const constructor to allow subtypes to be const.
   const BytesLoader();
 
   /// Load the byte data for a vector graphic binary asset.
-  Future<ByteData> loadBytes();
+  Future<ByteData> loadBytes(BuildContext context);
 }
 
-/// A controller for loading vector graphics data from an asset bundle.
+/// Loads vector graphics data from an asset bundle.
 class AssetBytesLoader extends BytesLoader {
-  /// Create a new [VectorGraphicsAssetController].
-  ///
-  /// The default asset bundle can be acquired using [DefaultAssetBundle.of].
   const AssetBytesLoader({
     required this.assetName,
     this.packageName,
-    required this.assetBundle,
+    this.assetBundle,
   });
 
   final String assetName;
   final String? packageName;
-  final AssetBundle assetBundle;
+  final AssetBundle? assetBundle;
 
   @override
-  Future<ByteData> loadBytes() {
-    return assetBundle.load(assetName);
+  Future<ByteData> loadBytes(BuildContext context) {
+    return (assetBundle ?? DefaultAssetBundle.of(context)).load(assetName);
+  }
+
+  @override
+  int get hashCode => Object.hash(assetName, packageName, assetBundle);
+
+  @override
+  bool operator ==(Object other) {
+    return other is AssetBytesLoader &&
+        other.assetName == assetName &&
+        other.assetBundle == assetBundle &&
+        other.packageName == packageName;
   }
 }
 
 /// A controller for loading vector graphics data from over the network.
 class NetworkBytesLoader extends BytesLoader {
+  /// Creates a new loading context for network bytes.
   const NetworkBytesLoader({
     required this.url,
     this.headers,
@@ -211,7 +226,7 @@ class NetworkBytesLoader extends BytesLoader {
   final HttpClient? client;
 
   @override
-  Future<ByteData> loadBytes() async {
+  Future<ByteData> loadBytes(BuildContext context) async {
     final HttpClient currentClient = client ?? HttpClient();
     final HttpClientRequest request = await currentClient.getUrl(url);
     headers?.forEach(request.headers.add);
@@ -225,6 +240,17 @@ class NetworkBytesLoader extends BytesLoader {
       response,
     );
     return bytes.buffer.asByteData();
+  }
+
+  @override
+  int get hashCode => Object.hash(url, headers, client);
+
+  @override
+  bool operator ==(Object other) {
+    return other is NetworkBytesLoader &&
+        other.headers == headers &&
+        other.url == url &&
+        other.client == client;
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -1,7 +1,7 @@
-import 'dart:typed_data';
-import 'dart:ui' as ui;
 import 'dart:io';
 import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -24,12 +24,16 @@ PictureInfo decodeVectorGraphics(ByteData data) {
   return listener.toPicture();
 }
 
-/// A widget that displays a vector_graphics formatted asset.
+/// A widget that displays a [VectorGraphicsCodec] encoded asset.
 ///
 /// This widget will repeatedly ask the loader to load the bytes when its
 /// dependencies change or it is configured with a new loader. A loader may
 /// or may not choose to used caching to respond to those requests.
 class VectorGraphic extends StatefulWidget {
+  /// A widget that displays a vector graphics created via a
+  /// [VectorGraphicsCodec].
+  ///
+  /// See [VectorGraphic].
   const VectorGraphic({
     Key? key,
     required this.loader,
@@ -171,14 +175,24 @@ abstract class BytesLoader {
 /// [AssetBundle] that caches data, or should create their own implementation
 /// of an asset bytes loader.
 class AssetBytesLoader extends BytesLoader {
+  /// A loader that retrieves bytes from an [AssetBundle].
+  ///
+  /// See [AssetBytesLoader].
   const AssetBytesLoader(
     this.assetName, {
     this.packageName,
     this.assetBundle,
   });
 
+  /// The name of the asset to load.
   final String assetName;
+
+  /// The package name to load from, if any.
   final String? packageName;
+
+  /// The asset bundle to use.
+  ///
+  /// If unspecified, [DefaultAssetBundle.of] the current context will be used.
   final AssetBundle? assetBundle;
 
   @override
@@ -209,8 +223,14 @@ class NetworkBytesLoader extends BytesLoader {
     this.client,
   });
 
+  /// The HTTP headers to use for the network request.
   final Map<String, String>? headers;
+
+  /// The [Uri] of the resource to request.
   final Uri url;
+
+  /// The [HttpClient] to use when making a request. By default, this will
+  /// create a new [HttpClient] per request.
   final HttpClient? client;
 
   @override
@@ -257,7 +277,9 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
 
   @override
   void updateRenderObject(
-      BuildContext context, covariant _RenderVectorGraphics renderObject) {
+    BuildContext context,
+    covariant _RenderVectorGraphics renderObject,
+  ) {
     renderObject.pictureInfo = pictureInfo;
   }
 }

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -26,30 +26,9 @@ PictureInfo decodeVectorGraphics(ByteData data) {
 
 /// A widget that displays a vector_graphics formatted asset.
 ///
-/// A bytes loader class should not be constructed directly in a build method,
-/// if this is done the corresponding [VectorGraphic] widget may repeatedly
-/// reload the bytes.
-///
-/// ```dart
-/// class MyVectorGraphic extends StatefulWidget {
-///   State<MyVectorGraphic> createState() => _MyVectorGraphicState();
-/// }
-///
-/// class _MyVectorGraphicState extends State<MyVectorGraphic> {
-///   BytesLoader? loader;
-///
-///   @override
-///   void initState() {
-///     super.initState();
-///     loader = AssetBytesLoader(assetName: 'foobar', assetBundle: DefaultAssetBundle.of(context));
-///   }
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return VectorGraphic(bytesLoader: loader!);
-///   }
-/// }
-/// ```
+/// This widget will repeatedly ask the loader to load the bytes when its
+/// dependencies change or it is configured with a new loader. A loader may
+/// or may not choose to used caching to respond to those requests.
 class VectorGraphic extends StatefulWidget {
   const VectorGraphic({
     Key? key,
@@ -184,9 +163,16 @@ abstract class BytesLoader {
 }
 
 /// Loads vector graphics data from an asset bundle.
+///
+/// This loader does not cache bytes by default. The Flutter framework
+/// implementations of [AssetBundle] also do not typically cache binary data.
+///
+/// Callers that would benefit from caching should provide a custom
+/// [AssetBundle] that caches data, or should create their own implementation
+/// of an asset bytes loader.
 class AssetBytesLoader extends BytesLoader {
-  const AssetBytesLoader({
-    required this.assetName,
+  const AssetBytesLoader(
+    this.assetName, {
     this.packageName,
     this.assetBundle,
   });
@@ -213,10 +199,12 @@ class AssetBytesLoader extends BytesLoader {
 }
 
 /// A controller for loading vector graphics data from over the network.
+///
+/// This loader does not cache bytes requested from the network.
 class NetworkBytesLoader extends BytesLoader {
   /// Creates a new loading context for network bytes.
-  const NetworkBytesLoader({
-    required this.url,
+  const NetworkBytesLoader(
+    this.url, {
     this.headers,
     this.client,
   });

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -125,7 +125,7 @@ void main() {
       bundle: testBundle,
       child: VectorGraphic(
         key: key,
-        loader: const AssetBytesLoader(assetName: 'foo.svg'),
+        loader: const AssetBytesLoader('foo.svg'),
       ),
     ));
 
@@ -136,7 +136,7 @@ void main() {
       bundle: testBundle,
       child: VectorGraphic(
         key: key,
-        loader: const AssetBytesLoader(assetName: 'foo.svg'),
+        loader: const AssetBytesLoader('foo.svg'),
       ),
     ));
 
@@ -152,7 +152,7 @@ void main() {
       bundle: testBundle,
       child: VectorGraphic(
         key: key,
-        loader: const AssetBytesLoader(assetName: 'foo.svg'),
+        loader: const AssetBytesLoader('foo.svg'),
       ),
     ));
 
@@ -162,7 +162,7 @@ void main() {
       bundle: testBundle,
       child: VectorGraphic(
         key: key,
-        loader: const AssetBytesLoader(assetName: 'bar.svg'),
+        loader: const AssetBytesLoader('bar.svg'),
       ),
     ));
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -11,13 +11,13 @@ const VectorGraphicsCodec codec = VectorGraphicsCodec();
 
 void main() {
   test('Can decode a message without a stroke and vertices', () {
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     final FlutterVectorGraphicsListener listener =
         FlutterVectorGraphicsListener();
     final int paintId = codec.writeStroke(buffer, 44, 1, 2, 3, 4.0, 6.0);
     codec.writeDrawVertices(
         buffer,
-        Float32List.fromList([
+        Float32List.fromList(<double>[
           0.0,
           2.0,
           3.0,
@@ -34,7 +34,7 @@ void main() {
   });
 
   test('Can decode a message with a fill and path', () {
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     final FlutterVectorGraphicsListener listener =
         FlutterVectorGraphicsListener();
     final int paintId = codec.writeFill(buffer, 23, 0);
@@ -60,7 +60,7 @@ void main() {
 
   testWidgets('Creates layout widgets when VectorGraphic is sized',
       (WidgetTester tester) async {
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     await tester.pumpWidget(VectorGraphic(
       loader: TestBytesLoader(buffer.done()),
       width: 100,
@@ -79,7 +79,7 @@ void main() {
 
   testWidgets('Creates alignment widgets when VectorGraphic is aligned',
       (WidgetTester tester) async {
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     await tester.pumpWidget(VectorGraphic(
       loader: TestBytesLoader(buffer.done()),
       alignment: Alignment.centerLeft,
@@ -98,7 +98,7 @@ void main() {
 
   testWidgets('Sizes VectorGraphic based on encoded viewbox information',
       (WidgetTester tester) async {
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     codec.writeSize(buffer, 100, 200);
 
     await tester.pumpWidget(VectorGraphic(
@@ -176,7 +176,7 @@ class TestAssetBundle extends Fake implements AssetBundle {
   @override
   Future<ByteData> load(String key) async {
     loadKeys.add(key);
-    final buffer = VectorGraphicsBuffer();
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     codec.writeSize(buffer, 100, 200);
     return buffer.done();
   }

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -20,13 +20,21 @@ import '../../vector_graphics_codec/test/vector_graphics_codec_test.dart'
         OnDrawPath;
 
 class TestBytesLoader extends BytesLoader {
-  TestBytesLoader(this.data);
+  const TestBytesLoader(this.data);
 
   final ByteData data;
 
   @override
-  Future<ByteData> loadBytes() async {
+  Future<ByteData> loadBytes(BuildContext context) async {
     return data;
+  }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TestBytesLoader && other.data == data;
   }
 }
 
@@ -38,7 +46,7 @@ void main() {
 
       await tester.pumpWidget(Center(
           child: VectorGraphic(
-              bytesLoader: TestBytesLoader(bytes.buffer.asByteData()))));
+              loader: TestBytesLoader(bytes.buffer.asByteData()))));
       await tester.pumpAndSettle();
 
       expect(tester.takeException(), isNull);


### PR DESCRIPTION
This makes our API match `Image.foo` a bit more, while still retaining constability.

So instead of

```dart
VectorGraphic(bytesLoader: AssetBytesLoader(assetName: 'foo.svg', assetBundle: DefaultAssetBundle.of(context)));
```

You can do 

```dart
const VectorGraphic(bytesLoader: AssetBytesLoader('foo.svg'));
```