### PR TITLE
create separate picture layer for vector graphics widget

### DIFF
--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -16,7 +16,7 @@ class PictureInfo {
   /// Retrieve the picture layer associated with this [PictureInfo].
   ///
   /// Will be null if info has already been disposed.
-  PictureLayer? get picture {
+  PictureLayer? get layer {
     return _handle.layer;
   }
 

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -1,15 +1,17 @@
 import 'dart:ui' as ui;
 import 'dart:typed_data';
 
+import 'package:flutter/rendering.dart';
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
-  const PictureInfo(this.picture, this.size);
+  const PictureInfo(this.handle, this.size);
 
-  /// The picture to be drawn with [ui.canvas.drawPicture]
-  final ui.Picture picture;
+  /// A [LayerHandle] that contains a picture layer with the decoded
+  /// vector graphic.
+  final LayerHandle<PictureLayer> handle;
 
   /// The target size of the picture.
   ///
@@ -55,7 +57,10 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   PictureInfo toPicture() {
     assert(!_done);
     _done = true;
-    return PictureInfo(_recorder.endRecording(), _size);
+    final LayerHandle<PictureLayer> handle = LayerHandle<PictureLayer>();
+    handle.layer = PictureLayer(Rect.fromLTWH(0, 0, _size.width, _size.height))
+      ..picture = _recorder.endRecording();
+    return PictureInfo(handle, _size);
   }
 
   @override

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -7,11 +7,25 @@ import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
-  const PictureInfo(this.handle, this.size);
+  PictureInfo._(this._handle, this.size);
 
   /// A [LayerHandle] that contains a picture layer with the decoded
   /// vector graphic.
-  final LayerHandle<PictureLayer> handle;
+  final LayerHandle<PictureLayer> _handle;
+
+  /// Retrieve the picture layer associated with this [PictureInfo].
+  ///
+  /// Will be null if info has already been disposed.
+  PictureLayer? get picture {
+    return _handle.layer;
+  }
+
+  //// Dispose this picture info.
+  ///
+  /// It is safe to call this method multiple times.
+  void dispose() {
+    _handle.layer = null;
+  }
 
   /// The target size of the picture.
   ///
@@ -60,7 +74,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     final LayerHandle<PictureLayer> handle = LayerHandle<PictureLayer>();
     handle.layer = PictureLayer(Rect.fromLTWH(0, 0, _size.width, _size.height))
       ..picture = _recorder.endRecording();
-    return PictureInfo(handle, _size);
+    return PictureInfo._(handle, _size);
   }
 
   @override

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:flutter/rendering.dart';
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
+const VectorGraphicsCodec _codec = VectorGraphicsCodec();
+
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
@@ -32,6 +34,16 @@ class PictureInfo {
   /// This information should be used to scale and position
   /// the picture based on the available space and alignment.
   final ui.Size size;
+}
+
+/// Decode a vector graphics binary asset into a [ui.Picture].
+///
+/// Throws a [StateError] if the data is invalid.
+PictureInfo decodeVectorGraphics(ByteData data) {
+  final FlutterVectorGraphicsListener listener =
+      FlutterVectorGraphicsListener();
+  _codec.decode(data, listener);
+  return listener.toPicture();
 }
 
 /// A listener implementation for the vector graphics codec that converts the

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -110,7 +110,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _pictureInfo?.picture.dispose();
+    _pictureInfo?.handle.layer = null;
     _pictureInfo = null;
     super.dispose();
   }
@@ -119,7 +119,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
     widget.loader.loadBytes(context).then((ByteData data) {
       final PictureInfo pictureInfo = decodeVectorGraphics(data);
       setState(() {
-        _pictureInfo?.picture.dispose();
+        _pictureInfo?.handle.layer = null;
         _pictureInfo = pictureInfo;
       });
     });
@@ -319,7 +319,7 @@ class _RenderVectorGraphics extends RenderBox {
     if (_scaleCanvasToViewBox(transform, size, pictureInfo.size)) {
       context.canvas.transform(transform.storage);
     }
-    context.canvas.drawPicture(_pictureInfo.picture);
+    context.addLayer(_pictureInfo.handle.layer!);
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -319,7 +319,7 @@ class _RenderVectorGraphics extends RenderBox {
     if (_scaleCanvasToViewBox(transform, size, pictureInfo.size)) {
       context.canvas.transform(transform.storage);
     }
-    context.addLayer(_pictureInfo.picture!);
+    context.addLayer(_pictureInfo.layer!);
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -10,20 +10,6 @@ import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
 import 'src/listener.dart';
 
-export 'src/listener.dart' show PictureInfo;
-
-const VectorGraphicsCodec _codec = VectorGraphicsCodec();
-
-/// Decode a vector graphics binary asset into a [ui.Picture].
-///
-/// Throws a [StateError] if the data is invalid.
-PictureInfo decodeVectorGraphics(ByteData data) {
-  final FlutterVectorGraphicsListener listener =
-      FlutterVectorGraphicsListener();
-  _codec.decode(data, listener);
-  return listener.toPicture();
-}
-
 /// A widget that displays a [VectorGraphicsCodec] encoded asset.
 ///
 /// This widget will ask the loader to load the bytes whenever its

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -110,7 +110,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _pictureInfo?.handle.layer = null;
+    _pictureInfo?.dispose();
     _pictureInfo = null;
     super.dispose();
   }
@@ -119,7 +119,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
     widget.loader.loadBytes(context).then((ByteData data) {
       final PictureInfo pictureInfo = decodeVectorGraphics(data);
       setState(() {
-        _pictureInfo?.handle.layer = null;
+        _pictureInfo?.dispose();
         _pictureInfo = pictureInfo;
       });
     });
@@ -319,7 +319,7 @@ class _RenderVectorGraphics extends RenderBox {
     if (_scaleCanvasToViewBox(transform, size, pictureInfo.size)) {
       context.canvas.transform(transform.storage);
     }
-    context.addLayer(_pictureInfo.handle.layer!);
+    context.addLayer(_pictureInfo.picture!);
   }
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_graphics/src/listener.dart';
@@ -167,6 +168,34 @@ void main() {
     ));
 
     expect(testBundle.loadKeys, <String>['foo.svg', 'bar.svg']);
+  });
+
+  testWidgets('Can update SVG picture', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: const VectorGraphic(
+          loader: AssetBytesLoader('foo.svg'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.layers, contains(isA<PictureLayer>()));
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: const VectorGraphic(
+          loader: AssetBytesLoader('bar.svg'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.layers, contains(isA<PictureLayer>()));
   });
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -197,6 +197,16 @@ void main() {
 
     expect(tester.layers, contains(isA<PictureLayer>()));
   });
+
+  testWidgets('PictureInfo.dispose is safe to call multiple times',
+      (WidgetTester tester) async {
+    final FlutterVectorGraphicsListener listener =
+        FlutterVectorGraphicsListener();
+    final PictureInfo info = listener.toPicture();
+
+    info.dispose();
+    expect(info.dispose, returnsNormally);
+  });
 }
 
 class TestAssetBundle extends Fake implements AssetBundle {


### PR DESCRIPTION
Similar to https://github.com/dnfield/flutter_svg/pull/592 . using canvas.drawPicture still defeats raster caching.