### PR TITLE
Tolerate missing references

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -118,7 +118,7 @@ class ParentNode extends AttributedNode {
     String? clipId,
     String? maskId,
     required Resolver<List<Path>> clipResolver,
-    required Resolver<AttributedNode> maskResolver,
+    required Resolver<AttributedNode?> maskResolver,
   }) {
     Node wrappedChild = child;
     if (clipId != null) {
@@ -243,10 +243,16 @@ class MaskNode extends Node {
   final BlendMode? blendMode;
 
   /// Called by [build] to resolve [maskId] to an [AttributedNode].
-  final Resolver<AttributedNode> resolver;
+  final Resolver<AttributedNode?> resolver;
 
   @override
   void build(DrawCommandBuilder builder, AffineMatrix transform) {
+    final AttributedNode? resolvedMask = resolver(maskId);
+    if (resolvedMask == null) {
+      child.build(builder, transform);
+      return;
+    }
+
     // Save layer expects to use the fill paint, and will unconditionally set
     // the color on the dart:ui.Paint object.
     builder.addSaveLayer(Paint(
@@ -256,7 +262,7 @@ class MaskNode extends Node {
     child.build(builder, transform);
     {
       builder.addMask();
-      resolver(maskId).build(builder, child.concatTransform(transform));
+      resolvedMask.build(builder, child.concatTransform(transform));
       builder.restore();
     }
     builder.restore();
@@ -324,7 +330,8 @@ class DeferredNode extends AttributedNode {
 
   /// The callback that materializes an [AttributedNode] for [refId] at [build]
   /// time.
-  final Resolver<AttributedNode> resolver;
+  final Resolver<AttributedNode?> resolver;
+
   @override
   AttributedNode applyAttributes(SvgAttributes newAttributes) {
     return DeferredNode(
@@ -336,8 +343,11 @@ class DeferredNode extends AttributedNode {
 
   @override
   void build(DrawCommandBuilder builder, AffineMatrix transform) {
-    final AttributedNode concreteRef =
-        resolver(refId).applyAttributes(attributes);
+    final AttributedNode? resolvedNode = resolver(refId);
+    if (resolvedNode == null) {
+      return;
+    }
+    final AttributedNode concreteRef = resolvedNode.applyAttributes(attributes);
     concreteRef.build(builder, transform);
   }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1056,8 +1056,6 @@ class SvgParser {
   List<Path> parseClipPath() {
     final String? id = _currentAttributes.clipPathId;
     if (id != null) {
-      // If this returns null it should be an error, but for now match
-      // flutter_svg behavior.
       return _definitions.getClipPath(id);
     }
 
@@ -1406,19 +1404,19 @@ class _Resolver {
     _sealed = true;
   }
 
-  AttributedNode getDrawable(String ref) {
+  AttributedNode? getDrawable(String ref) {
     assert(_sealed);
-    return _drawables[ref]!;
+    return _drawables[ref];
   }
 
   List<Path> getClipPath(String ref) {
     assert(_sealed);
-    return _clips[ref]!;
+    return _clips[ref] ?? <Path>[];
   }
 
-  T getGradient<T extends Gradient>(String ref) {
+  T? getGradient<T extends Gradient>(String ref) {
     assert(_sealed);
-    return _shaders[ref]! as T;
+    return _shaders[ref] as T?;
   }
 
   final Map<String, List<Gradient>> _deferredShaders =
@@ -1681,8 +1679,12 @@ class SvgStrokeAttributes {
     if (shaderId != null) {
       shader = _definitions!
           .getGradient<Gradient>(shaderId!)
-          .applyBounds(shaderBounds, transform);
+          ?.applyBounds(shaderBounds, transform);
+      if (shader == null) {
+        return null;
+      }
     }
+
     return Stroke(
       color: color,
       shader: shader,
@@ -1722,8 +1724,12 @@ class SvgFillAttributes {
     if (shaderId != null) {
       shader = _definitions!
           .getGradient<Gradient>(shaderId!)
-          .applyBounds(shaderBounds, transform);
+          ?.applyBounds(shaderBounds, transform);
+      if (shader == null) {
+        return null;
+      }
     }
+
     return Fill(color: color, shader: shader);
   }
 }

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -6,6 +6,22 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Missing references', () async {
+    final VectorInstructions instructions = await parse(missingRefs);
+    expect(
+      instructions.paints.single,
+      const Paint(fill: Fill(color: Color(0xFFFF0000))),
+    );
+    expect(
+      instructions.paths.single,
+      PathBuilder().addRect(const Rect.fromLTWH(5, 5, 100, 100)).toPath(),
+    );
+    expect(
+      instructions.commands.single,
+      const DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
+    );
+  });
+
   test('focal radial', () async {
     final VectorInstructions instructions = await parse(focalRadial);
 

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -971,3 +971,11 @@ const String focalRadial = '''
       style="fill: url(#radial); stroke: black;"/>
 </svg>
 ''';
+
+/// A constructed SVG with a bunch of missing references.
+const String missingRefs = '''
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 120 120">
+  <rect x="5" y="5" width="100" height="100" mask="url(#myMask)" clip="url(#myClip)" fill="red" stroke="url(#gradient)"/>
+  <use xlink:href="url(#nope)" />
+</svg>
+''';


### PR DESCRIPTION
In flutter_svg, these emit warnings because they might be failures to parse. Here they'll never be failures to parse, but erroring is too strong. I'm having trouble finding exactly what the spec says about this, but this is how browsers handle these things - and in the SVG test suite there are examples of SVGs that intentionally provide invalid references but are still expected to render.