### PR TITLE
Cleanup and support web

### DIFF
--- a/packages/vector_graphics/example/pubspec.yaml
+++ b/packages/vector_graphics/example/pubspec.yaml
@@ -33,3 +33,11 @@ dependency_overrides:
     path: ../../vector_graphics_codec
   vector_graphics:
     path: ../
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:

--- a/packages/vector_graphics/lib/src/_http_io.dart
+++ b/packages/vector_graphics/lib/src/_http_io.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+
+/// Fetches an HTTP resource from the specified [uri] using the specified [headers].
+Future<Uint8List> httpGet(Uri uri, {Map<String, String>? headers}) async {
+  final HttpClient httpClient = HttpClient();
+  final HttpClientRequest request = await httpClient.getUrl(uri);
+  if (headers != null) {
+    headers.forEach((String key, String value) {
+      request.headers.add(key, value);
+    });
+  }
+  final HttpClientResponse response = await request.close();
+
+  if (response.statusCode != HttpStatus.ok) {
+    throw HttpException('Could not get network asset', uri: uri);
+  }
+  return consolidateHttpClientResponseBytes(response);
+}

--- a/packages/vector_graphics/lib/src/_http_io.dart
+++ b/packages/vector_graphics/lib/src/_http_io.dart
@@ -7,14 +7,14 @@ import 'package:flutter/foundation.dart';
 Future<Uint8List> httpGet(Uri uri, {Map<String, String>? headers}) async {
   final HttpClient httpClient = HttpClient();
   final HttpClientRequest request = await httpClient.getUrl(uri);
-  if (headers != null) {
-    headers.forEach((String key, String value) {
-      request.headers.add(key, value);
-    });
-  }
+  headers?.forEach(request.headers.add);
   final HttpClientResponse response = await request.close();
 
   if (response.statusCode != HttpStatus.ok) {
+    // The network may be only temporarily unavailable, or the file will be
+    // added on the server later. Avoid having future calls fail to check the
+    // network again.
+    await response.drain<List<int>>(<int>[]);
     throw HttpException('Could not get network asset', uri: uri);
   }
   return consolidateHttpClientResponseBytes(response);

--- a/packages/vector_graphics/lib/src/_http_web.dart
+++ b/packages/vector_graphics/lib/src/_http_web.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 // This lint is currently broken for packages that say they support web.
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html';
@@ -10,5 +9,10 @@ Future<Uint8List> httpGet(Uri uri, {Map<String, String>? headers}) async {
     uri.toString(),
     requestHeaders: headers,
   );
-  return Uint8List.fromList(utf8.encode(request.responseText!));
+  request.responseType = 'arraybuffer';
+  if (request.response is Uint8List) {
+    return request.response as Uint8List;
+  } else {
+    return Uint8List.fromList(request.response as List<int>);
+  }
 }

--- a/packages/vector_graphics/lib/src/_http_web.dart
+++ b/packages/vector_graphics/lib/src/_http_web.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+// This lint is currently broken for packages that say they support web.
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html';
+import 'dart:typed_data';
+
+/// Fetches an HTTP resource from the specified [url] using the specified [headers].
+Future<Uint8List> httpGet(Uri uri, {Map<String, String>? headers}) async {
+  final HttpRequest request = await HttpRequest.request(
+    uri.toString(),
+    requestHeaders: headers,
+  );
+  return Uint8List.fromList(utf8.encode(request.responseText!));
+}

--- a/packages/vector_graphics/lib/src/http.dart
+++ b/packages/vector_graphics/lib/src/http.dart
@@ -1,0 +1,1 @@
+export '_http_io.dart' if (dart.library.html) '_http_web.dart';

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -21,3 +21,11 @@ dev_dependencies:
 dependency_overrides:
   vector_graphics_codec:
     path: ../vector_graphics_codec
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:

--- a/packages/vector_graphics_codec/pubspec.yaml
+++ b/packages/vector_graphics_codec/pubspec.yaml
@@ -9,3 +9,11 @@ environment:
 dev_dependencies:
   flutter_lints: ^1.0.0
   test: ^1.20.1
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:

--- a/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
+++ b/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
@@ -7,6 +7,7 @@ class DrawCommandBuilder {
   final Map<Paint, int> _paints = <Paint, int>{};
   final Map<Path, int> _paths = <Path, int>{};
   final Map<TextConfig, int> _text = <TextConfig, int>{};
+
   final List<DrawCommand> _commands = <DrawCommand>[];
 
   int _getOrGenerateId<T>(T object, Map<T, int> map) =>

--- a/packages/vector_graphics_compiler/lib/src/paint.dart
+++ b/packages/vector_graphics_compiler/lib/src/paint.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:meta/meta.dart';
 
 import 'geometry/basic_types.dart';
@@ -1315,3 +1317,18 @@ const FontWeight normalFontWeight = FontWeight.w400;
 
 /// A commonly used font weight that is heavier than normal.
 const FontWeight boldFontWeight = FontWeight.w700;
+
+/// The raw data of a raster image and its rendering information.
+abstract class ImageData {
+  /// The raw encoded raster data.
+  Uint8List get image;
+
+  /// The target width of the image.
+  double get width;
+
+  /// The target height of the image.
+  double get height;
+
+  /// The transform to apply to the image.s
+  AffineMatrix get transform;
+}

--- a/packages/vector_graphics_compiler/lib/src/paint.dart
+++ b/packages/vector_graphics_compiler/lib/src/paint.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:meta/meta.dart';
 
 import 'geometry/basic_types.dart';

--- a/packages/vector_graphics_compiler/lib/src/paint.dart
+++ b/packages/vector_graphics_compiler/lib/src/paint.dart
@@ -1317,18 +1317,3 @@ const FontWeight normalFontWeight = FontWeight.w400;
 
 /// A commonly used font weight that is heavier than normal.
 const FontWeight boldFontWeight = FontWeight.w700;
-
-/// The raw data of a raster image and its rendering information.
-abstract class ImageData {
-  /// The raw encoded raster data.
-  Uint8List get image;
-
-  /// The target width of the image.
-  double get width;
-
-  /// The target height of the image.
-  double get height;
-
-  /// The transform to apply to the image.s
-  AffineMatrix get transform;
-}

--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -234,7 +234,7 @@ class ClipNode extends Node {
     String? id,
   });
 
-  /// Called by [build] to resolve [clipId] to a list of paths.
+  /// Called by visitors to resolve [clipId] to a list of paths.
   final Resolver<List<Path>> resolver;
 
   /// The clips to apply to the child node.
@@ -292,7 +292,7 @@ class MaskNode extends Node {
   /// The decendant child's transform
   final AffineMatrix transform;
 
-  /// Called by [build] to resolve [maskId] to an [AttributedNode].
+  /// Called by visitors to resolve [maskId] to an [AttributedNode].
   final Resolver<AttributedNode?> resolver;
 
   @override
@@ -357,11 +357,11 @@ class PathNode extends AttributedNode {
   }
 }
 
-/// A node that refers to another node, and uses [resolver] at [build] time
+/// A node that refers to another node, and supplies a [resolver] for visitors
 /// to materialize the referenced node into the tree.
 class DeferredNode extends AttributedNode {
   /// Creates a new deferred node with [attributes] that will call [resolver]
-  /// with [refId] at [build] time.
+  /// with [refId] when visited.
   DeferredNode(
     SvgAttributes attributes, {
     required this.refId,
@@ -371,8 +371,8 @@ class DeferredNode extends AttributedNode {
   /// The reference id to pass to [resolver].
   final String refId;
 
-  /// The callback that materializes an [AttributedNode] for [refId] at [build]
-  /// time.
+  /// The callback that materializes an [AttributedNode] for [refId] when
+  /// visited.
   final Resolver<AttributedNode?> resolver;
 
   @override

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -343,42 +343,7 @@ class _Elements {
 
   static Future<void> image(
       SvgParser parserState, bool warningsAsErrors) async {
-    throw UnsupportedError('TODO');
-    // final String? href = parserState._currentAttributes.href;
-    // if (href == null) {
-    //   return;
-    // }
-    // final Point offset = Point(
-    //   parserState.parseDoubleWithUnits(
-    //     parserState.attribute('x', def: '0'),
-    //   )!,
-    //   parserState.parseDoubleWithUnits(
-    //     parserState.attribute('y', def: '0'),
-    //   )!,
-    // );
-    // final Size size = Size(
-    //   parserState.parseDoubleWithUnits(
-    //     parserState.attribute('width', def: '0'),
-    //   )!,
-    //   parserState.parseDoubleWithUnits(
-    //     parserState.attribute('height', def: '0'),
-    //   )!,
-    // );
-    // final Image image = await resolveImage(href);
-    // final ParentNode parent = parserState._parentDrawables.last.drawable!;
-    // final DrawableStyle? parentStyle = parent.paint;
-    // final DrawableRasterImage drawable = DrawableRasterImage(
-    //   parserState.attribute('id', def: ''),
-    //   image,
-    //   offset,
-    //   parserState.parseStyle(parserState.rootBounds, parentStyle,
-    //       currentColor: parent.color),
-    //   size: size,
-    //   transform: parseTransform(parserState.attribute('transform'))?.storage,
-    // );
-    // parserState.checkForIri(drawable);
-
-    // parserState.currentGroup!.children!.add(drawable);
+    throw UnsupportedError('The <image> tag is not supported by this library.');
   }
 
   static Future<void> text(

--- a/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
@@ -120,58 +120,6 @@ PathFillType? parseRawFillRule(String? rawFillRule) {
   return rawFillRule != 'evenodd' ? PathFillType.nonZero : PathFillType.evenOdd;
 }
 
-// final RegExp _whitespacePattern = RegExp(r'\s');
-
-// /// Resolves an image reference, potentially downloading it via HTTP.
-// Future<Image> resolveImage(String href) async {
-//   assert(href != '');
-
-//   final Future<Image> Function(Uint8List) decodeImage =
-//       (Uint8List bytes) async {
-//     final Codec codec = await instantiateImageCodec(bytes);
-//     final FrameInfo frame = await codec.getNextFrame();
-//     return frame.image;
-//   };
-
-//   if (href.startsWith('http')) {
-//     throw UnsupportedError('Cannot request http images');
-//   }
-
-//   if (href.startsWith('data:')) {
-//     final int commaLocation = href.indexOf(',') + 1;
-//     final Uint8List bytes = base64.decode(
-//         href.substring(commaLocation).replaceAll(_whitespacePattern, ''));
-//     return decodeImage(bytes);
-//   }
-
-//   throw UnsupportedError('Could not resolve image href: $href');
-// }
-
-// const ParagraphConstraints _infiniteParagraphConstraints = ParagraphConstraints(
-//   width: double.infinity,
-// );
-
-// /// A [DrawablePaint] with a transparent stroke.
-// const DrawablePaint transparentStroke =
-//     DrawablePaint(PaintingStyle.stroke, color: Color(0x0));
-
-// /// Creates a [Paragraph] object using the specified [text], [style], and
-// /// [foregroundOverride].
-// Paragraph createParagraph(
-//   String text,
-//   DrawableStyle style,
-//   DrawablePaint? foregroundOverride,
-// ) {
-//   final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle())
-//     ..pushStyle(
-//       style.textStyle!.toFlutterTextStyle(
-//         foregroundOverride: foregroundOverride,
-//       ),
-//     )
-//     ..addText(text);
-//   return builder.build()..layout(_infiniteParagraphConstraints);
-// }
-
 /// Parses strings in the form of '1.0' or '100%'.
 double parseDecimalOrPercentage(String val, {double multiplier = 1.0}) {
   if (isPercentage(val)) {

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -31,3 +31,11 @@ dev_dependencies:
 dependency_overrides:
   vector_graphics_codec:
     path: ../vector_graphics_codec
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:


### PR DESCRIPTION
Things I found while working on #58 

This patch drops all code related to images, and throws a slightly more meaningful exception if an image is encountered. We should figure out a better error handling strategy than that in the compiler.

It updates some stale docs that I noticed, fixes some minor formatting issues, does some light refactoring of repetitive code in the codec, and makes the example app run on web (including running the compiler in the browser).