### PR TITLE
Defer resolving paths for clips, add test for clips with use

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
+++ b/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import 'package:vector_graphics_compiler/src/util.dart';
 
 import 'geometry/path.dart';
 import 'geometry/vertices.dart';
@@ -10,6 +11,7 @@ import 'paint.dart';
 
 /// An immutable collection of vector instructions, with [width] and [height]
 /// specifying the viewport coordinates.
+@immutable
 class VectorInstructions {
   /// Creates a new set of [VectorInstructions].
   ///
@@ -50,6 +52,28 @@ class VectorInstructions {
   ///
   /// If drawing using vertices, the [Paint.stroke] property is ignored.
   final List<DrawCommand> commands;
+
+  @override
+  int get hashCode => Object.hash(
+      width,
+      height,
+      Object.hashAll(paints),
+      Object.hashAll(paths),
+      Object.hashAll(vertices),
+      Object.hashAll(text),
+      Object.hashAll(commands));
+
+  @override
+  bool operator ==(Object other) {
+    return other is VectorInstructions &&
+        other.width == width &&
+        other.height == height &&
+        listEquals(other.paints, paints) &&
+        listEquals(other.paths, paths) &&
+        listEquals(other.vertices, vertices) &&
+        listEquals(other.text, text) &&
+        listEquals(other.commands, commands);
+  }
 
   @override
   String toString() => 'VectorInstructions($width, $height)';

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -6,6 +6,12 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Clip with use', () async {
+    final VectorInstructions instructions = await parse(basicClip);
+    final VectorInstructions instructions2 = await parse(useClip);
+    expect(instructions, instructions2);
+  });
+
   test('Dashed path', () async {
     final VectorInstructions instructions = await parse('''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -79,6 +79,23 @@ const String multiClip = '''
 </svg>
 ''';
 
+/// Constructed example based on [basicClip] that has refs.
+const String useClip = '''
+<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <circle id="a" cx="30" cy="30" r="20"/>
+    <clipPath id="myClip">
+      <use xlink:href="#a" />
+      <use xlink:href="#b" />
+    </clipPath>
+     <circle id="b" cx="70" cy="70" r="20"/>
+  </defs>
+
+  <rect x="10" y="10" width="100" height="100"
+      clip-path="url(#myClip)"/>
+</svg>
+''';
+
 /// https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity
 const String basicOpacity = '''
 <svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This got broken when I added asserts to make sure we didn't try to access potentially deferred data until parsing was done. Adds a test. 