### PR TITLE
Wrap picture in repaint boundary

### DIFF
--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -182,7 +182,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
         child: child,
       );
     }
-    return child;
+    return RepaintBoundary(child: child);
   }
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -243,6 +243,22 @@ void main() {
     expect(tester.layers, contains(isA<PictureLayer>()));
   });
 
+  testWidgets('Uses repaint boundary', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: const VectorGraphic(
+          loader: AssetBytesLoader('foo.svg'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RepaintBoundary), findsOneWidget);
+  });
+
   testWidgets('PictureInfo.dispose is safe to call multiple times',
       (WidgetTester tester) async {
     final FlutterVectorGraphicsListener listener =


### PR DESCRIPTION
We'd like to avoid repainting the vector graphic unnecessarily - and we know that structurally everything in this picture will update at once. This might be the cause of the slightly reduced raster performance