### PR TITLE
Clip the fitted box if it would overflow

### DIFF
--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -166,6 +166,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
       child: FittedBox(
         fit: widget.fit,
         alignment: widget.alignment,
+        clipBehavior: Clip.hardEdge,
         child: SizedBox.fromSize(
           size: pictureInfo.size,
           child: _RawVectorGraphicsWidget(

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -140,6 +140,7 @@ void main() {
 
     expect(fittedBox.fit, BoxFit.fitHeight);
     expect(fittedBox.alignment, Alignment.centerLeft);
+    expect(fittedBox.clipBehavior, Clip.hardEdge);
   });
 
   testWidgets('Sizes VectorGraphic based on encoded viewbox information',


### PR DESCRIPTION
Fixes issue where if the user selects a particular fit that results in overflow, the overflow would show.

Fitted boxes do try to avoid clipping if unnecessary, so this should not add cost when it's not needed.