### PR TITLE
dont force extra compositing

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -21,7 +21,6 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      checkerboardRasterCacheImages: true,
       title: 'Vector Graphics Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -21,6 +21,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      checkerboardRasterCacheImages: true,
       title: 'Vector Graphics Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
@@ -29,9 +30,6 @@ class MyApp extends StatelessWidget {
         body: Center(
           child: ListView(
             children: const <Widget>[
-              VectorGraphic(
-                loader: AssetBytesLoader('assets/tiger.bin'),
-              ),
               VectorGraphic(
                 loader: NetworkSvgLoader(
                   'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -6,7 +6,6 @@ import 'dart:ui' as ui;
 import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/rendering.dart';
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
 const VectorGraphicsCodec _codec = VectorGraphicsCodec();
@@ -14,25 +13,10 @@ const VectorGraphicsCodec _codec = VectorGraphicsCodec();
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
-  PictureInfo._(this._handle, this.size);
+  PictureInfo._(this.picture, this.size);
 
-  /// A [LayerHandle] that contains a picture layer with the decoded
-  /// vector graphic.
-  final LayerHandle<PictureLayer> _handle;
-
-  /// Retrieve the picture layer associated with this [PictureInfo].
-  ///
-  /// Will be null if info has already been disposed.
-  PictureLayer? get layer {
-    return _handle.layer;
-  }
-
-  //// Dispose this picture info.
-  ///
-  /// It is safe to call this method multiple times.
-  void dispose() {
-    _handle.layer = null;
-  }
+  /// A picture generated from a vector graphics image.
+  final ui.Picture picture;
 
   /// The target size of the picture.
   ///
@@ -131,10 +115,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   PictureInfo toPicture() {
     assert(!_done);
     _done = true;
-    final LayerHandle<PictureLayer> handle = LayerHandle<PictureLayer>();
-    handle.layer = PictureLayer(Rect.fromLTWH(0, 0, _size.width, _size.height))
-      ..picture = _recorder.endRecording();
-    return PictureInfo._(handle, _size);
+    return PictureInfo._(_recorder.endRecording(), _size);
   }
 
   @override

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -122,7 +122,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _pictureInfo?.dispose();
+    _pictureInfo?.picture.dispose();
     _pictureInfo = null;
     super.dispose();
   }
@@ -135,7 +135,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
         textDirection: Directionality.maybeOf(context),
       );
       setState(() {
-        _pictureInfo?.dispose();
+        _pictureInfo?.picture.dispose();
         _pictureInfo = pictureInfo;
       });
     });
@@ -339,9 +339,6 @@ class _RenderVectorGraphics extends RenderBox {
     return constraints.smallest;
   }
 
-  @override
-  bool get isRepaintBoundary => true;
-
   final Matrix4 transform = Matrix4.identity();
 
   @override
@@ -349,7 +346,12 @@ class _RenderVectorGraphics extends RenderBox {
     if (_scaleCanvasToViewBox(transform, size, pictureInfo.size)) {
       context.canvas.transform(transform.storage);
     }
-    context.addLayer(_pictureInfo.layer!);
+    // Instead of using an explicit non-owned layer here, we just add
+    // the picture directly. This allows parent render objects to avoid
+    // extra compositing.
+    // This is safe to do because the widget itself is wrapped in a repaint
+    // boundary.
+    context.canvas.drawPicture(_pictureInfo.picture);
   }
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -404,7 +404,8 @@ void main() {
 
   // Show that we avoid compositing extra layers and raster cache the maximum number of paint
   // operations.
-  testWidgets('Only creates a PictureLayer and a repaint boundary', (WidgetTester tester) async {
+  testWidgets('Only creates a PictureLayer and a repaint boundary',
+      (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
 
     await tester.pumpWidget(
@@ -425,7 +426,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.layers.last, isA<PictureLayer>()); // vg picture
-    expect(tester.layers.elementAt(tester.layers.length - 2), isA<OffsetLayer>()); // Repaint boundary
+    expect(tester.layers.elementAt(tester.layers.length - 2),
+        isA<OffsetLayer>()); // Repaint boundary
   });
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -270,16 +270,6 @@ void main() {
     expect(find.byType(RepaintBoundary), findsOneWidget);
   });
 
-  testWidgets('PictureInfo.dispose is safe to call multiple times',
-      (WidgetTester tester) async {
-    final FlutterVectorGraphicsListener listener =
-        FlutterVectorGraphicsListener();
-    final PictureInfo info = listener.toPicture();
-
-    info.dispose();
-    expect(info.dispose, returnsNormally);
-  });
-
   testWidgets('Can set locale and text direction', (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
     await tester.pumpWidget(
@@ -410,6 +400,32 @@ void main() {
     );
 
     expect(find.byKey(const ValueKey<int>(23)), findsOneWidget);
+  });
+
+  // Show that we avoid compositing extra layers and raster cache the maximum number of paint
+  // operations.
+  testWidgets('Only creates a PictureLayer and a repaint boundary', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: VectorGraphic(
+            loader: const AssetBytesLoader('foo.svg'),
+            semanticsLabel: 'Foo',
+            placeholderBuilder: (BuildContext context) {
+              return Container(key: const ValueKey<int>(23));
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.layers.last, isA<PictureLayer>()); // vg picture
+    expect(tester.layers.elementAt(tester.layers.length - 2), isA<OffsetLayer>()); // Repaint boundary
   });
 }
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/103089

If we add an explicit picture layer, then we force parent clips and future color filters to be layers. Since we have a repaint boundary, it is instead safe to add the picutre directly with Canvas.drawPicture which removes several layer types and ensures that these operations are all cached if the picture would be cached.

