### PR TITLE
Filter/Opacity support and eager rasterization

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
 import 'dart:developer';
 import 'dart:typed_data';
 
@@ -33,6 +34,8 @@ class MyApp extends StatelessWidget {
                 loader: NetworkSvgLoader(
                   'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
                 ),
+                color: Colors.red,
+                blendMode: ui.BlendMode.screen
               )
             ],
           ),

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
 import 'dart:developer';
 import 'dart:typed_data';
 
@@ -32,8 +31,6 @@ class MyApp extends StatelessWidget {
             loader: NetworkSvgLoader(
               'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
             ),
-            color: Colors.red,
-            blendMode: ui.BlendMode.colorBurn,
           ),
         ),
       ),

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -21,7 +21,6 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      checkerboardRasterCacheImages: true,
       title: 'Vector Graphics Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -26,18 +26,14 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: Scaffold(
+      home: const Scaffold(
         body: Center(
-          child: ListView(
-            children: const <Widget>[
-              VectorGraphic(
-                loader: NetworkSvgLoader(
-                  'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
-                ),
-                color: Colors.red,
-                blendMode: ui.BlendMode.screen
-              )
-            ],
+          child: VectorGraphic(
+            loader: NetworkSvgLoader(
+              'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
+            ),
+            color: Colors.red,
+            blendMode: ui.BlendMode.colorBurn,
           ),
         ),
       ),
@@ -54,7 +50,6 @@ class NetworkSvgLoader extends BytesLoader {
   Future<ByteData> loadBytes(BuildContext context) async {
     return await compute((String svgUrl) async {
       final http.Response request = await http.get(Uri.parse(svgUrl));
-      // print('Got respone for $svgUrl: (${request.statusCode}) ${request.contentLength} bytes');
       final TimelineTask task = TimelineTask()..start('encodeSvg');
       final Uint8List compiledBytes = await encodeSvg(request.body, svgUrl);
       task.finish();

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -21,6 +21,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      checkerboardRasterCacheImages: true,
       title: 'Vector Graphics Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
@@ -29,9 +30,6 @@ class MyApp extends StatelessWidget {
         body: Center(
           child: ListView(
             children: const <Widget>[
-              VectorGraphic(
-                loader: AssetBytesLoader('assets/tiger.bin'),
-              ),
               VectorGraphic(
                 loader: NetworkSvgLoader(
                   'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -6,7 +6,6 @@ import 'dart:ui' as ui;
 import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/rendering.dart';
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
 const VectorGraphicsCodec _codec = VectorGraphicsCodec();
@@ -14,25 +13,10 @@ const VectorGraphicsCodec _codec = VectorGraphicsCodec();
 /// The deocded result of a vector graphics asset.
 class PictureInfo {
   /// Construct a new [PictureInfo].
-  PictureInfo._(this._handle, this.size);
+  PictureInfo._(this.picture, this.size);
 
-  /// A [LayerHandle] that contains a picture layer with the decoded
-  /// vector graphic.
-  final LayerHandle<PictureLayer> _handle;
-
-  /// Retrieve the picture layer associated with this [PictureInfo].
-  ///
-  /// Will be null if info has already been disposed.
-  PictureLayer? get layer {
-    return _handle.layer;
-  }
-
-  //// Dispose this picture info.
-  ///
-  /// It is safe to call this method multiple times.
-  void dispose() {
-    _handle.layer = null;
-  }
+  /// A picture generated from a vector graphics image.
+  final ui.Picture picture;
 
   /// The target size of the picture.
   ///
@@ -131,10 +115,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   PictureInfo toPicture() {
     assert(!_done);
     _done = true;
-    final LayerHandle<PictureLayer> handle = LayerHandle<PictureLayer>();
-    handle.layer = PictureLayer(Rect.fromLTWH(0, 0, _size.width, _size.height))
-      ..picture = _recorder.endRecording();
-    return PictureInfo._(handle, _size);
+    return PictureInfo._(_recorder.endRecording(), _size);
   }
 
   @override

--- a/packages/vector_graphics/lib/src/render_vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphics.dart
@@ -12,7 +12,6 @@ import 'listener.dart';
 
 /// A render object which draws a vector graphic instance as a raster.
 class RenderVectorGraphic extends RenderBox {
-
   /// Create a new [RenderVectorGraphic].
   RenderVectorGraphic(
     this._pictureInfo,
@@ -58,7 +57,7 @@ class RenderVectorGraphic extends RenderBox {
   double get opacity => _opacity;
   double _opacity;
   set opacity(double value) {
-    assert(value >= 0.0  && value <= 1.0);
+    assert(value >= 0.0 && value <= 1.0);
     if (value == opacity) {
       return;
     }
@@ -90,6 +89,7 @@ class RenderVectorGraphic extends RenderBox {
     }
     return _pendingRasterUpdate;
   }
+
   Future<void>? _pendingRasterUpdate;
 
   // Re-create the raster for a given SVG if the target size

--- a/packages/vector_graphics/lib/src/render_vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphics.dart
@@ -1,0 +1,191 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import 'listener.dart';
+
+/// A render object which draws a vector graphic instance as a raster.
+class RenderVectorGraphic extends RenderBox {
+
+  /// Create a new [RenderVectorGraphic].
+  RenderVectorGraphic(
+    this._pictureInfo,
+    this._colorFilter,
+    this._devicePixelRatio,
+    this._opacity,
+  );
+
+  /// The [PictureInfo] which contains the vector graphic and size to draw.
+  PictureInfo get pictureInfo => _pictureInfo;
+  PictureInfo _pictureInfo;
+  set pictureInfo(PictureInfo value) {
+    if (identical(value, _pictureInfo)) {
+      return;
+    }
+    _pictureInfo = value;
+    _invalidateRaster();
+  }
+
+  /// An optional [ColorFilter] to apply to the rasterized vector graphic.
+  ColorFilter? get colorFilter => _colorFilter;
+  ColorFilter? _colorFilter;
+  set colorFilter(ColorFilter? value) {
+    if (colorFilter == value) {
+      return;
+    }
+    _colorFilter = value;
+    markNeedsPaint();
+  }
+
+  /// The device pixel ratio the vector graphic should be rasterized at.
+  double get devicePixelRatio => _devicePixelRatio;
+  double _devicePixelRatio;
+  set devicePixelRatio(double value) {
+    if (value == devicePixelRatio) {
+      return;
+    }
+    _devicePixelRatio = value;
+    _invalidateRaster();
+  }
+
+  /// An opacity to draw the rasterized vector graphic with.
+  double get opacity => _opacity;
+  double _opacity;
+  set opacity(double value) {
+    assert(value >= 0.0  && value <= 1.0);
+    if (value == opacity) {
+      return;
+    }
+    _opacity = value;
+    markNeedsPaint();
+  }
+
+  @override
+  bool hitTestSelf(Offset position) => true;
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    return constraints.smallest;
+  }
+
+  void _invalidateRaster() {
+    _lastRasterizedSize = null;
+    markNeedsPaint();
+  }
+
+  /// Visible for testing only.
+  @visibleForTesting
+  Future<void>? get pendingRasterUpdate {
+    if (kReleaseMode) {
+      return null;
+    }
+    return _pendingRasterUpdate;
+  }
+  Future<void>? _pendingRasterUpdate;
+
+  // Re-create the raster for a given SVG if the target size
+  // is sufficiently different.
+  Future<void> _maybeUpdateRaster(Size desiredSize) async {
+    double scale = 1.0;
+    if (desiredSize != pictureInfo.size) {
+      scale = math.min(
+        desiredSize.width / pictureInfo.size.width,
+        desiredSize.height / pictureInfo.size.height,
+      );
+    }
+    final int scaledWidth = (pictureInfo.size.width * scale).round();
+    final int scaledHeight = (pictureInfo.size.height * scale).round();
+    if (_lastRasterizedSize != null &&
+        _lastRasterizedSize!.width == scaledWidth &&
+        _lastRasterizedSize!.height == scaledHeight) {
+      return;
+    }
+    final ui.Image result = await pictureInfo.picture.toImage(
+        (scaledWidth * devicePixelRatio).round(),
+        (scaledHeight * devicePixelRatio).round());
+    _currentImage?.dispose();
+    _currentImage = result;
+    _lastRasterizedSize = Size(scaledWidth.toDouble(), scaledHeight.toDouble());
+    markNeedsPaint();
+  }
+
+  Size? _lastRasterizedSize;
+  ui.Image? _currentImage;
+
+  @override
+  void dispose() {
+    _currentImage?.dispose();
+    _currentImage = null;
+    super.dispose();
+  }
+
+  @override
+  void paint(PaintingContext context, ui.Offset offset) {
+    if (opacity <= 0.0) {
+      return;
+    }
+
+    final Offset pictureOffset = _pictureOffset(size, pictureInfo.size);
+    final ui.Image? image = _currentImage;
+    _pendingRasterUpdate = _maybeUpdateRaster(size);
+    if (image == null || _lastRasterizedSize == null) {
+      return;
+    }
+
+    // Use `FilterQuality.low` to scale the image, which corresponds to
+    // bilinear interpolation.
+    final Paint colorPaint = Paint()..filterQuality = ui.FilterQuality.low;
+    if (colorFilter != null) {
+      colorPaint.colorFilter = colorFilter!;
+    }
+    colorPaint.color = const Color(0xFFFFFFFF).withOpacity(opacity);
+    final Offset dstOffset = offset + pictureOffset;
+    final Rect src = ui.Rect.fromLTWH(
+      0,
+      0,
+      pictureInfo.size.width,
+      pictureInfo.size.height,
+    );
+    final Rect dst = ui.Rect.fromLTWH(
+      dstOffset.dx,
+      dstOffset.dy,
+      _lastRasterizedSize!.width,
+      _lastRasterizedSize!.height,
+    );
+    context.canvas.drawImageRect(
+      image,
+      src,
+      dst,
+      colorPaint,
+    );
+  }
+}
+
+Offset _pictureOffset(
+  Size desiredSize,
+  Size pictureSize,
+) {
+  if (desiredSize == pictureSize) {
+    return Offset.zero;
+  }
+  final double scale = math.min(
+    desiredSize.width / pictureSize.width,
+    desiredSize.height / pictureSize.height,
+  );
+  final Size scaledHalfViewBoxSize = pictureSize * scale / 2.0;
+  final Size halfDesiredSize = desiredSize / 2.0;
+  final Offset shift = Offset(
+    halfDesiredSize.width - scaledHalfViewBoxSize.width,
+    halfDesiredSize.height - scaledHalfViewBoxSize.height,
+  );
+  return shift;
+}

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -316,7 +316,7 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
     return _RenderVectorGraphics(
       pictureInfo,
       colorFilter,
-      MediaQuery.of(context).devicePixelRatio,
+      MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
     );
   }
 
@@ -328,7 +328,7 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
     renderObject
       ..pictureInfo = pictureInfo
       ..colorFilter = colorFilter
-      ..devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+      ..devicePixelRatio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0;
   }
 }
 
@@ -427,7 +427,7 @@ class _RenderVectorGraphics extends RenderBox {
     final Offset pictureOffset = _pictureOffset(size, pictureInfo.size);
     final ui.Image? image = _currentImage;
     _maybeUpdateRaster(size);
-    if (image == null) {
+    if (image == null || _lastRasterizedSize == null) {
       return;
     }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -313,11 +313,8 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderVectorGraphics(
-      pictureInfo,
-      colorFilter,
-      MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
-    );
+    return _RenderVectorGraphics(pictureInfo, colorFilter,
+        MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0);
   }
 
   @override

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -39,6 +39,8 @@ class VectorGraphic extends StatefulWidget {
     this.semanticsLabel,
     this.excludeFromSemantics = false,
     this.placeholderBuilder,
+    this.color,
+    this.blendMode = BlendMode.srcIn,
   }) : super(key: key);
 
   /// A delegate for fetching the raw bytes of the vector graphic.
@@ -98,6 +100,16 @@ class VectorGraphic extends StatefulWidget {
 
   /// The placeholder to use while fetching, decoding, and parsing the vector_graphics data.
   final WidgetBuilder? placeholderBuilder;
+
+  /// If provided, a color to blend with the vector graphic according to a
+  /// given [blendMode].
+  final Color? color;
+
+  /// If a [color] is provided, the blend mode used to draw the vector graphic
+  /// with.
+  ///
+  /// Defaults to [BlendMode.srcIn].
+  final BlendMode blendMode;
 
   @override
   State<VectorGraphic> createState() => _VectorGraphicsWidgetState();
@@ -174,6 +186,8 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
             size: pictureInfo.size,
             child: _RawVectorGraphicsWidget(
               pictureInfo: pictureInfo,
+              color: widget.color,
+              blendMode: widget.blendMode,
             ),
           ),
         ),
@@ -297,13 +311,17 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
   const _RawVectorGraphicsWidget({
     Key? key,
     required this.pictureInfo,
+    required this.color,
+    required this.blendMode,
   }) : super(key: key);
 
   final PictureInfo pictureInfo;
+  final Color? color;
+  final BlendMode blendMode;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _RenderVectorGraphics(pictureInfo);
+    return _RenderVectorGraphics(pictureInfo, color, blendMode);
   }
 
   @override
@@ -311,12 +329,15 @@ class _RawVectorGraphicsWidget extends SingleChildRenderObjectWidget {
     BuildContext context,
     covariant _RenderVectorGraphics renderObject,
   ) {
-    renderObject.pictureInfo = pictureInfo;
+    renderObject
+      ..pictureInfo = pictureInfo
+      ..color = color
+      ..blendMode = blendMode;
   }
 }
 
 class _RenderVectorGraphics extends RenderBox {
-  _RenderVectorGraphics(this._pictureInfo);
+  _RenderVectorGraphics(this._pictureInfo, this._color, this._blendMode);
 
   PictureInfo get pictureInfo => _pictureInfo;
   PictureInfo _pictureInfo;
@@ -325,6 +346,26 @@ class _RenderVectorGraphics extends RenderBox {
       return;
     }
     _pictureInfo = value;
+    markNeedsPaint();
+  }
+
+  BlendMode get blendMode => _blendMode;
+  BlendMode _blendMode;
+  set blendMode(BlendMode value) {
+    if (blendMode == value) {
+      return;
+    }
+    _blendMode = value;
+    markNeedsPaint();
+  }
+
+  Color? get color => _color;
+  Color? _color;
+  set color(Color? value) {
+    if (color == value) {
+      return;
+    }
+    _color = value;
     markNeedsPaint();
   }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -344,7 +344,6 @@ class _RenderVectorGraphics extends RenderBox {
     }
     _pictureInfo = value;
     invalidateRaster();
-    markNeedsPaint();
   }
 
   ColorFilter? get colorFilter => _colorFilter;
@@ -365,7 +364,6 @@ class _RenderVectorGraphics extends RenderBox {
     }
     _devicePixelRatio = value;
     invalidateRaster();
-    markNeedsPaint();
   }
 
   @override
@@ -381,6 +379,7 @@ class _RenderVectorGraphics extends RenderBox {
 
   void invalidateRaster() {
     _lastRasterizedSize = null;
+    markNeedsPaint();
   }
 
   // Re-create the raster for a given SVG if the target size
@@ -428,6 +427,8 @@ class _RenderVectorGraphics extends RenderBox {
       return;
     }
 
+    // Use `FilterQuality.low` to scale the image, which corresponds to
+    // bilinear interpolation.
     final Paint colorPaint = Paint()..filterQuality = ui.FilterQuality.low;
     if (colorFilter != null) {
       colorPaint.colorFilter = colorFilter!;
@@ -451,7 +452,6 @@ class _RenderVectorGraphics extends RenderBox {
       dst,
       colorPaint,
     );
-    return;
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -122,7 +122,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _pictureInfo?.dispose();
+    _pictureInfo?.picture.dispose();
     _pictureInfo = null;
     super.dispose();
   }
@@ -135,7 +135,7 @@ class _VectorGraphicsWidgetState extends State<VectorGraphic> {
         textDirection: Directionality.maybeOf(context),
       );
       setState(() {
-        _pictureInfo?.dispose();
+        _pictureInfo?.picture.dispose();
         _pictureInfo = pictureInfo;
       });
     });
@@ -339,9 +339,6 @@ class _RenderVectorGraphics extends RenderBox {
     return constraints.smallest;
   }
 
-  @override
-  bool get isRepaintBoundary => true;
-
   final Matrix4 transform = Matrix4.identity();
 
   @override
@@ -349,7 +346,12 @@ class _RenderVectorGraphics extends RenderBox {
     if (_scaleCanvasToViewBox(transform, size, pictureInfo.size)) {
       context.canvas.transform(transform.storage);
     }
-    context.addLayer(_pictureInfo.layer!);
+    // Instead of using an explicit non-owned layer here, we just add
+    // the picture directly. This allows parent render objects to avoid
+    // extra compositing.
+    // This is safe to do because the widget itself is wrapped in a repaint
+    // boundary.
+    context.canvas.drawPicture(_pictureInfo.picture);
   }
 }
 

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -393,6 +393,10 @@ class _RenderVectorGraphics extends RenderBox {
     // This is safe to do because the widget itself is wrapped in a repaint
     // boundary.
     context.canvas.drawPicture(_pictureInfo.picture);
+
+    if (color != null) {
+      context.canvas.drawColor(color!, blendMode);
+    }
   }
 }
 

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -1,0 +1,197 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_graphics/src/listener.dart';
+import 'package:vector_graphics/src/render_vector_graphics.dart';
+import 'package:vector_graphics_codec/vector_graphics_codec.dart';
+
+void main() {
+  late PictureInfo pictureInfo;
+
+  setUpAll(() {
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
+    const VectorGraphicsCodec().writeSize(buffer, 30, 50);
+
+    pictureInfo = decodeVectorGraphics(
+      buffer.done(),
+      locale: const Locale('fr', 'CH'),
+      textDirection: TextDirection.ltr,
+    );
+  });
+
+  test('Rasterizes a picture to a draw image call', () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      1.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    // No rasterization yet.
+    expect(context.canvas.lastImage, isNull);
+
+    await renderVectorGraphic.pendingRasterUpdate;
+
+    // When the rasterization is finished, it marks self as needing paint.
+    expect(renderVectorGraphic.debugNeedsPaint, true);
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    expect(context.canvas.lastImage, isNotNull);
+  });
+
+  test('Changing color filter does not re-rasterize', () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      1.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    final ui.Image firstImage = context.canvas.lastImage!;
+
+    renderVectorGraphic.colorFilter =
+        const ui.ColorFilter.mode(Colors.red, ui.BlendMode.colorBurn);
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+
+    expect(firstImage.debugDisposed, false);
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    expect(context.canvas.lastImage, equals(firstImage));
+  });
+
+  test('Changing device pixel ratio does re-rasterize and dispose old raster',
+      () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      1.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    final ui.Image firstImage = context.canvas.lastImage!;
+
+    renderVectorGraphic.devicePixelRatio = 2.0;
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+
+    expect(firstImage.debugDisposed, true);
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    expect(context.canvas.lastImage!.debugDisposed, false);
+  });
+
+  test('Changing size does re-rasterize and dispose old raster', () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      1.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    final ui.Image firstImage = context.canvas.lastImage!;
+
+    // change size.
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(1000, 1000)));
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+
+    expect(firstImage.debugDisposed, true);
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    expect(context.canvas.lastImage!.debugDisposed, false);
+  });
+
+  test('Does not rasterize a picture when fully transparent', () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      0.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    // No rasterization yet.
+    expect(context.canvas.lastImage, isNull);
+    expect(renderVectorGraphic.pendingRasterUpdate, isNull);
+
+    renderVectorGraphic.opacity = 1.0;
+
+    // Changing opacity requires painting.
+    expect(renderVectorGraphic.debugNeedsPaint, true);
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    // Rasterization is now pending.
+    expect(renderVectorGraphic.pendingRasterUpdate, isNotNull);
+  });
+
+  test('Disposing render object disposes picture', () async {
+    final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
+      pictureInfo,
+      null,
+      1.0,
+      1.0,
+    );
+    renderVectorGraphic.layout(BoxConstraints.tight(const Size(100, 100)));
+    final FakePaintingContext context = FakePaintingContext();
+    renderVectorGraphic.paint(context, Offset.zero);
+    await renderVectorGraphic.pendingRasterUpdate;
+
+    renderVectorGraphic.paint(context, Offset.zero);
+
+    final ui.Image lastImage = context.canvas.lastImage!;
+
+    renderVectorGraphic.dispose();
+
+    expect(lastImage.debugDisposed, true);
+  });
+}
+
+class FakeCanvas extends Fake implements Canvas {
+  ui.Image? lastImage;
+  Rect? lastSrc;
+  Rect? lastDst;
+  Paint? lastPaint;
+
+  @override
+  void drawImageRect(ui.Image image, Rect src, Rect dst, Paint paint) {
+    lastImage = image;
+    lastSrc = src;
+    lastDst = dst;
+    lastPaint = paint;
+  }
+}
+
+class FakePaintingContext extends Fake implements PaintingContext {
+  @override
+  final FakeCanvas canvas = FakeCanvas();
+}

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -404,7 +404,8 @@ void main() {
 
   // Show that we avoid compositing extra layers and raster cache the maximum number of paint
   // operations.
-  testWidgets('Only creates a PictureLayer and a repaint boundary', (WidgetTester tester) async {
+  testWidgets('Only creates a PictureLayer and a repaint boundary',
+      (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
 
     await tester.pumpWidget(
@@ -425,7 +426,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.layers.last, isA<PictureLayer>()); // vg picture
-    expect(tester.layers.elementAt(tester.layers.length - 2), isA<OffsetLayer>()); // Repaint boundary
+    expect(tester.layers.elementAt(tester.layers.length - 2),
+        isA<OffsetLayer>()); // Repaint boundary
   });
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -270,16 +270,6 @@ void main() {
     expect(find.byType(RepaintBoundary), findsOneWidget);
   });
 
-  testWidgets('PictureInfo.dispose is safe to call multiple times',
-      (WidgetTester tester) async {
-    final FlutterVectorGraphicsListener listener =
-        FlutterVectorGraphicsListener();
-    final PictureInfo info = listener.toPicture();
-
-    info.dispose();
-    expect(info.dispose, returnsNormally);
-  });
-
   testWidgets('Can set locale and text direction', (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
     await tester.pumpWidget(
@@ -410,6 +400,32 @@ void main() {
     );
 
     expect(find.byKey(const ValueKey<int>(23)), findsOneWidget);
+  });
+
+  // Show that we avoid compositing extra layers and raster cache the maximum number of paint
+  // operations.
+  testWidgets('Only creates a PictureLayer and a repaint boundary', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: testBundle,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: VectorGraphic(
+            loader: const AssetBytesLoader('foo.svg'),
+            semanticsLabel: 'Foo',
+            placeholderBuilder: (BuildContext context) {
+              return Container(key: const ValueKey<int>(23));
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.layers.last, isA<PictureLayer>()); // vg picture
+    expect(tester.layers.elementAt(tester.layers.length - 2), isA<OffsetLayer>()); // Repaint boundary
   });
 }
 

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -254,22 +254,6 @@ void main() {
     expect(tester.layers, contains(isA<PictureLayer>()));
   });
 
-  testWidgets('Uses repaint boundary', (WidgetTester tester) async {
-    final TestAssetBundle testBundle = TestAssetBundle();
-
-    await tester.pumpWidget(
-      DefaultAssetBundle(
-        bundle: testBundle,
-        child: const VectorGraphic(
-          loader: AssetBytesLoader('foo.svg'),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.byType(RepaintBoundary), findsOneWidget);
-  });
-
   testWidgets('Can set locale and text direction', (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
     await tester.pumpWidget(
@@ -400,34 +384,6 @@ void main() {
     );
 
     expect(find.byKey(const ValueKey<int>(23)), findsOneWidget);
-  });
-
-  // Show that we avoid compositing extra layers and raster cache the maximum number of paint
-  // operations.
-  testWidgets('Only creates a PictureLayer and a repaint boundary',
-      (WidgetTester tester) async {
-    final TestAssetBundle testBundle = TestAssetBundle();
-
-    await tester.pumpWidget(
-      DefaultAssetBundle(
-        bundle: testBundle,
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: VectorGraphic(
-            loader: const AssetBytesLoader('foo.svg'),
-            semanticsLabel: 'Foo',
-            placeholderBuilder: (BuildContext context) {
-              return Container(key: const ValueKey<int>(23));
-            },
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(tester.layers.last, isA<PictureLayer>()); // vg picture
-    expect(tester.layers.elementAt(tester.layers.length - 2),
-        isA<OffsetLayer>()); // Repaint boundary
   });
 }
 


### PR DESCRIPTION
If we don't use a ColorFiltered widget, then the color filter can be combined with the rest of the paint operations and raster cached as a single picture. However, I haven't quite figured out the right order of operations here, so put up as a proof of concept.