### PR TITLE
Add caching system for pictures and rasters

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
-import 'dart:typed_data'; // ignore: unnecessary_import
+// ignore: unnecessary_import
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
+// ignore this while we wait for framework to catch up with g3.
 // ignore: unnecessary_import
 import 'dart:typed_data';
 

--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
-import 'dart:typed_data';
+import 'dart:typed_data'; // ignore: unnecessary_import
 
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';

--- a/packages/vector_graphics/lib/src/_http_io.dart
+++ b/packages/vector_graphics/lib/src/_http_io.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:typed_data'; // ignore: unnecessary_import
+// ignore: unnecessary_import
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 

--- a/packages/vector_graphics/lib/src/_http_io.dart
+++ b/packages/vector_graphics/lib/src/_http_io.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+// ignore this while we wait for framework to catch up with g3.
 // ignore: unnecessary_import
 import 'dart:typed_data';
 

--- a/packages/vector_graphics/lib/src/_http_io.dart
+++ b/packages/vector_graphics/lib/src/_http_io.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:typed_data';
+import 'dart:typed_data'; // ignore: unnecessary_import
 
 import 'package:flutter/foundation.dart';
 

--- a/packages/vector_graphics/lib/src/render_vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphics.dart
@@ -239,7 +239,8 @@ class RenderVectorGraphic extends RenderBox {
       _rasterData = data;
       return null; // immediate update.
     }
-    return _createRaster(key, devicePixelRatio / scale).then((_RasterData data) {
+    return _createRaster(key, devicePixelRatio / scale)
+        .then((_RasterData data) {
       data.count += 1;
       // Ensure this is only added to the live cache once.
       if (data.count == 1) {

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -140,11 +140,47 @@ class VectorGraphic extends StatefulWidget {
   State<VectorGraphic> createState() => _VectorGraphicWidgetState();
 }
 
+class _PictureData {
+  _PictureData(this.pictureInfo, this.count, this.key);
+
+  final PictureInfo pictureInfo;
+  _PictureKey key;
+  int count = 0;
+}
+
+@immutable
+class _PictureKey {
+  const _PictureKey(this.cacheKey, this.locale, this.textDirection);
+
+  final Object cacheKey;
+  final Locale? locale;
+  final TextDirection? textDirection;
+
+  @override
+  int get hashCode => Object.hash(cacheKey, locale, textDirection);
+
+  @override
+  bool operator ==(Object other) =>
+      other is _PictureKey &&
+      other.cacheKey == cacheKey &&
+      other.locale == locale &&
+      other.textDirection == textDirection;
+}
+
 class _VectorGraphicWidgetState extends State<VectorGraphic> {
-  PictureInfo? _pictureInfo;
+  _PictureData? _pictureInfo;
+  Locale? locale;
+  TextDirection? textDirection;
+
+  static final Map<_PictureKey, _PictureData> _livePictureCache =
+      <_PictureKey, _PictureData>{};
+  static final Map<_PictureKey, Future<_PictureData>> _pendingPictures =
+      <_PictureKey, Future<_PictureData>>{};
 
   @override
   void didChangeDependencies() {
+    locale = Localizations.maybeLocaleOf(context);
+    textDirection = Directionality.maybeOf(context);
     _loadAssetBytes();
     super.didChangeDependencies();
   }
@@ -159,31 +195,80 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
 
   @override
   void dispose() {
-    _pictureInfo?.picture.dispose();
+    _maybeReleasePicture(_pictureInfo);
     _pictureInfo = null;
     super.dispose();
   }
 
-  void _loadAssetBytes() {
-    widget.loader.loadBytes(context).then((ByteData data) {
-      if (!mounted) {
-        return;
-      }
+  void _maybeReleasePicture(_PictureData? data) {
+    if (data == null) {
+      return;
+    }
+    data.count -= 1;
+    if (data.count <= 0) {
+      _livePictureCache.remove(data.key);
+      data.pictureInfo.picture.dispose();
+    }
+  }
+
+  static Future<_PictureData> _loadPicture(
+      BuildContext context, _PictureKey key, BytesLoader loader) {
+    if (_pendingPictures.containsKey(key)) {
+      return _pendingPictures[key]!;
+    }
+    final Future<_PictureData> result =
+        loader.loadBytes(context).then((ByteData data) {
       final PictureInfo pictureInfo = decodeVectorGraphics(
         data,
-        locale: Localizations.maybeLocaleOf(context),
-        textDirection: Directionality.maybeOf(context),
+        locale: key.locale,
+        textDirection: key.textDirection,
       );
+      return _PictureData(pictureInfo, 0, key);
+    });
+    _pendingPictures[key] = result;
+    result.whenComplete(() {
+      _pendingPictures.remove(key);
+    });
+    return result;
+  }
+
+  void _loadAssetBytes() {
+    // First check if we have an avilable picture and use this immediately.
+    final Object loaderKey = widget.loader.cacheKey(context);
+    final _PictureKey key = _PictureKey(loaderKey, locale, textDirection);
+    final _PictureData? data = _livePictureCache[key];
+    if (data != null) {
+      data.count += 1;
       setState(() {
-        _pictureInfo?.picture.dispose();
-        _pictureInfo = pictureInfo;
+        _maybeReleasePicture(_pictureInfo);
+        _pictureInfo = data;
+      });
+      return;
+    }
+    // If not, then check if there is a pending load.
+    final BytesLoader loader = widget.loader;
+    _loadPicture(context, key, loader).then((_PictureData data) {
+      data.count += 1;
+
+      // The widget may have changed, requesting a new vector graphic before
+      // this operation could complete.
+      if (!mounted || loader != widget.loader) {
+        _maybeReleasePicture(data);
+        return;
+      }
+      if (data.count == 1) {
+        _livePictureCache[key] = data;
+      }
+      setState(() {
+        _maybeReleasePicture(_pictureInfo);
+        _pictureInfo = data;
       });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final PictureInfo? pictureInfo = _pictureInfo;
+    final PictureInfo? pictureInfo = _pictureInfo?.pictureInfo;
 
     Widget child;
     if (pictureInfo != null) {
@@ -263,6 +348,15 @@ abstract class BytesLoader {
 
   /// Load the byte data for a vector graphic binary asset.
   Future<ByteData> loadBytes(BuildContext context);
+
+  /// Create an object that can be used to uniquely identify this asset
+  /// and loader combination.
+  ///
+  /// For most [BytesLoader] subclasses, this can safely return the same
+  /// instance. If the loader looks up additional dependencies using the
+  /// [context] argument of [loadBytes], then those objects should be
+  /// incorporated into a new cache key.
+  Object cacheKey(BuildContext context) => this;
 }
 
 /// Loads vector graphics data from an asset bundle.
@@ -305,6 +399,40 @@ class AssetBytesLoader extends BytesLoader {
   @override
   bool operator ==(Object other) {
     return other is AssetBytesLoader &&
+        other.assetName == assetName &&
+        other.assetBundle == assetBundle &&
+        other.packageName == packageName;
+  }
+
+  @override
+  Object cacheKey(BuildContext context) {
+    return _AssetByteLoaderCacheKey(
+      assetName,
+      packageName,
+      assetBundle ?? DefaultAssetBundle.of(context),
+    );
+  }
+}
+
+// Replaces the cache key for [AssetBytesLoader] to account for the fact that
+// different widgets may select a different asset bundle based on the return
+// value of `DefaultAssetBundle.of(context)`.
+@immutable
+class _AssetByteLoaderCacheKey {
+  const _AssetByteLoaderCacheKey(
+      this.assetName, this.packageName, this.assetBundle);
+
+  final String assetName;
+  final String? packageName;
+
+  final AssetBundle assetBundle;
+
+  @override
+  int get hashCode => Object.hash(assetName, packageName, assetBundle);
+
+  @override
+  bool operator ==(Object other) {
+    return other is _AssetByteLoaderCacheKey &&
         other.assetName == assetName &&
         other.assetBundle == assetBundle &&
         other.packageName == packageName;

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -307,6 +307,7 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
             size: pictureInfo.size,
             child: _RawVectorGraphicWidget(
               pictureInfo: pictureInfo,
+              assetKey: _pictureInfo!.key,
               colorFilter: widget.colorFilter,
               opacity: widget.opacity,
               scale: scale,
@@ -478,17 +479,20 @@ class _RawVectorGraphicWidget extends SingleChildRenderObjectWidget {
     required this.colorFilter,
     required this.opacity,
     required this.scale,
+    required this.assetKey,
   });
 
   final PictureInfo pictureInfo;
   final ColorFilter? colorFilter;
   final double scale;
   final Animation<double>? opacity;
+  final Object assetKey;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
     return RenderVectorGraphic(
       pictureInfo,
+      assetKey,
       colorFilter,
       MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
       opacity,
@@ -503,6 +507,7 @@ class _RawVectorGraphicWidget extends SingleChildRenderObjectWidget {
   ) {
     renderObject
       ..pictureInfo = pictureInfo
+      ..assetKey = assetKey
       ..colorFilter = colorFilter
       ..devicePixelRatio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
       ..opacity = opacity

--- a/packages/vector_graphics/test/caching_test.dart
+++ b/packages/vector_graphics/test/caching_test.dart
@@ -1,0 +1,357 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_graphics/vector_graphics.dart';
+import 'package:vector_graphics_codec/vector_graphics_codec.dart';
+
+const VectorGraphicsCodec codec = VectorGraphicsCodec();
+
+void main() {
+  testWidgets(
+      'Does not reload identical bytes when forced to re-create state object',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      key: UniqueKey(),
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys.single, 'foo.svg');
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      key: UniqueKey(),
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys, <String>['foo.svg']);
+  });
+
+  testWidgets('Only loads bytes once for a repeated vg',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        key: UniqueKey(),
+        bundle: testBundle,
+        child: Column(
+          children: <Widget>[
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(testBundle.loadKeys.single, 'foo.svg');
+
+    await tester.pumpWidget(const SizedBox());
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        key: UniqueKey(),
+        bundle: testBundle,
+        child: Column(
+          children: <Widget>[
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+            VectorGraphic(
+              key: GlobalKey(),
+              loader: const AssetBytesLoader('foo.svg'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(testBundle.loadKeys, <String>['foo.svg', 'foo.svg']);
+  });
+
+  testWidgets('Does not cache bytes that come from different asset bundles',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundleA = TestAssetBundle();
+    final TestAssetBundle testBundleB = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      key: UniqueKey(),
+      bundle: testBundleA,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundleA.loadKeys.single, 'foo.svg');
+    expect(testBundleB.loadKeys, isEmpty);
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      key: UniqueKey(),
+      bundle: testBundleB,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundleA.loadKeys.single, 'foo.svg');
+    expect(testBundleB.loadKeys.single, 'foo.svg');
+  });
+
+  testWidgets('reload bytes when locale changes', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(
+      Localizations(
+        delegates: <LocalizationsDelegate<Object?>>[
+          TestLocalizationsDelegate()
+        ],
+        locale: const Locale('fr', 'CH'),
+        child: DefaultAssetBundle(
+          bundle: testBundle,
+          child: VectorGraphic(
+            key: key,
+            loader: const AssetBytesLoader('foo.svg'),
+          ),
+        ),
+      ),
+    );
+    // async localization loading requires extra pump and settle.
+    await tester.pumpAndSettle();
+
+    expect(testBundle.loadKeys.single, 'foo.svg');
+
+    await tester.pumpWidget(
+      Localizations(
+        delegates: <LocalizationsDelegate<Object?>>[
+          TestLocalizationsDelegate()
+        ],
+        locale: const Locale('ab', 'cd'),
+        child: DefaultAssetBundle(
+          bundle: testBundle,
+          child: VectorGraphic(
+            key: key,
+            loader: const AssetBytesLoader('foo.svg'),
+          ),
+        ),
+      ),
+    );
+    // async localization loading requires extra pump and settle.
+    await tester.pumpAndSettle();
+
+    expect(testBundle.loadKeys, <String>['foo.svg', 'foo.svg']);
+  });
+
+  testWidgets('reload bytes when text direction changes',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DefaultAssetBundle(
+          bundle: testBundle,
+          child: VectorGraphic(
+            key: key,
+            loader: const AssetBytesLoader('foo.svg'),
+          ),
+        ),
+      ),
+    );
+
+    expect(testBundle.loadKeys.single, 'foo.svg');
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: DefaultAssetBundle(
+          bundle: testBundle,
+          child: VectorGraphic(
+            key: key,
+            loader: const AssetBytesLoader('foo.svg'),
+          ),
+        ),
+      ),
+    );
+
+    expect(testBundle.loadKeys, <String>['foo.svg', 'foo.svg']);
+  });
+
+  testWidgets(
+      'Cache is purged immediately after last VectorGraphic removed from tree',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys.single, 'foo.svg');
+
+    // Force VectorGraphic removed from tree.
+    await tester.pumpWidget(const SizedBox());
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys, <String>['foo.svg', 'foo.svg']);
+  });
+
+  // For this test we evaluate an edge case where asset loading starts, but then a new
+  // asset is requested before the first can load. We want to ensure that first asset does
+  // not populate the cache in such a way that it gets "stuck".
+  testWidgets('Bytes loading that becomes stale does not populate the cache',
+      (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final GlobalKey key = GlobalKey();
+    final ControlledAssetBytesLoader loader =
+        ControlledAssetBytesLoader('foo.svg');
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: loader,
+      ),
+    ));
+
+    expect(testBundle.loadKeys, isEmpty);
+
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('bar.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys, <String>['bar.svg']);
+    loader.completer.complete();
+    await tester.pumpAndSettle();
+
+    expect(testBundle.loadKeys, <String>['bar.svg', 'foo.svg']);
+
+    // Even though foo.svg was loaded above, it should have been immediately discarded since
+    // the vector graphic widget was no longer requesting it. Thus we should see it loaded
+    // a second time below.
+    await tester.pumpWidget(DefaultAssetBundle(
+      bundle: testBundle,
+      child: VectorGraphic(
+        key: key,
+        loader: const AssetBytesLoader('foo.svg'),
+      ),
+    ));
+
+    expect(testBundle.loadKeys, <String>['bar.svg', 'foo.svg', 'foo.svg']);
+  });
+}
+
+class TestAssetBundle extends Fake implements AssetBundle {
+  final List<String> loadKeys = <String>[];
+
+  @override
+  Future<ByteData> load(String key) async {
+    loadKeys.add(key);
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
+    codec.writeSize(buffer, 100, 200);
+    return buffer.done();
+  }
+}
+
+class TestBytesLoader extends BytesLoader {
+  const TestBytesLoader(this.data);
+
+  final ByteData data;
+
+  @override
+  Future<ByteData> loadBytes(BuildContext context) async {
+    return data;
+  }
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is TestBytesLoader && other.data == data;
+  }
+}
+
+class ControlledAssetBytesLoader extends AssetBytesLoader {
+  ControlledAssetBytesLoader(super.assetName);
+
+  final Completer<void> completer = Completer<void>();
+
+  @override
+  Future<ByteData> loadBytes(BuildContext context) async {
+    await completer.future;
+    return super.loadBytes(context);
+  }
+}
+
+class TestLocalizationsDelegate
+    extends LocalizationsDelegate<WidgetsLocalizations> {
+  @override
+  bool isSupported(Locale locale) {
+    return true;
+  }
+
+  @override
+  Future<WidgetsLocalizations> load(Locale locale) async {
+    return TestWidgetsLocalizations();
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<WidgetsLocalizations> old) {
+    return false;
+  }
+}
+
+class TestWidgetsLocalizations extends WidgetsLocalizations {
+  @override
+  TextDirection get textDirection => TextDirection.ltr;
+}

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -33,6 +33,7 @@ void main() {
   test('Rasterizes a picture to a draw image call', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -58,6 +59,7 @@ void main() {
   test('Multiple render objects with the same scale share a raster', () async {
     final RenderVectorGraphic renderVectorGraphicA = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -65,6 +67,7 @@ void main() {
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -94,6 +97,7 @@ void main() {
   test('disposing render object release raster', () async {
     final RenderVectorGraphic renderVectorGraphicA = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -101,6 +105,7 @@ void main() {
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -132,6 +137,7 @@ void main() {
       () async {
     final RenderVectorGraphic renderVectorGraphicA = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -139,6 +145,7 @@ void main() {
     );
     final RenderVectorGraphic renderVectorGraphicB = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -169,6 +176,7 @@ void main() {
   test('Changing color filter does not re-rasterize', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -198,6 +206,7 @@ void main() {
       () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -225,6 +234,7 @@ void main() {
   test('Changing scale does re-rasterize and dispose old raster', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -252,6 +262,7 @@ void main() {
   test('The raster size is increased by the inverse picture scale', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -272,6 +283,7 @@ void main() {
   test('The raster size is increased by the device pixel ratio', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       2.0,
       null,
@@ -292,6 +304,7 @@ void main() {
       () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       2.0,
       null,
@@ -312,6 +325,7 @@ void main() {
       () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -334,6 +348,7 @@ void main() {
     final FixedOpacityAnimation opacity = FixedOpacityAnimation(0.0);
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       opacity,
@@ -363,6 +378,7 @@ void main() {
     final FixedOpacityAnimation opacity = FixedOpacityAnimation(0.5);
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       opacity,
@@ -382,6 +398,7 @@ void main() {
   test('Disposing render object disposes picture', () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -405,6 +422,7 @@ void main() {
       () async {
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       null,
@@ -422,6 +440,7 @@ void main() {
     final FixedOpacityAnimation opacity = FixedOpacityAnimation(0.5);
     final RenderVectorGraphic renderVectorGraphic = RenderVectorGraphic(
       pictureInfo,
+      'test',
       null,
       1.0,
       opacity,

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -173,34 +173,6 @@ void main() {
     expect(sizedBox.height, 200);
   });
 
-  testWidgets('Reloads bytes when position changes in tree',
-      (WidgetTester tester) async {
-    final TestAssetBundle testBundle = TestAssetBundle();
-    final GlobalKey key = GlobalKey();
-
-    await tester.pumpWidget(DefaultAssetBundle(
-      key: UniqueKey(),
-      bundle: testBundle,
-      child: VectorGraphic(
-        key: key,
-        loader: const AssetBytesLoader('foo.svg'),
-      ),
-    ));
-
-    expect(testBundle.loadKeys.single, 'foo.svg');
-
-    await tester.pumpWidget(DefaultAssetBundle(
-      key: UniqueKey(),
-      bundle: testBundle,
-      child: VectorGraphic(
-        key: key,
-        loader: const AssetBytesLoader('foo.svg'),
-      ),
-    ));
-
-    expect(testBundle.loadKeys, <String>['foo.svg', 'foo.svg']);
-  });
-
   testWidgets('Reloads bytes when configuration changes',
       (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
@@ -389,6 +361,8 @@ void main() {
 
   testWidgets('Does not call setState after unmounting',
       (WidgetTester tester) async {
+    final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
+    codec.writeSize(buffer, 100, 200);
     final Completer<ByteData> completer = Completer<ByteData>();
 
     await tester.pumpWidget(
@@ -400,7 +374,7 @@ void main() {
       ),
     );
     await tester.pumpWidget(const Placeholder());
-    completer.complete(ByteData(0));
+    completer.complete(buffer.done());
   });
 }
 


### PR DESCRIPTION
Ensure that repeats of the "same" vector graphic both recycle the loading/decoding of their pictures, and if the same size, the computation of their raster images.

Unlike either the flutter image cache or svg picture cache, this only attempts to keep picture info and rasters "live" while at least one widget in the tree is using it. Thus, the primary goal is to reduce the cost of repeating the same vg multiple times 