### PR TITLE
Prevent double disposal of pictures/images

### DIFF
--- a/packages/vector_graphics/lib/src/render_vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphics.dart
@@ -222,7 +222,7 @@ class RenderVectorGraphic extends RenderBox {
       return;
     }
     data.count -= 1;
-    if (data.count <= 0) {
+    if (data.count == 0 && _liveRasterCache.containsKey(data.key)) {
       _liveRasterCache.remove(data.key);
       data.image.dispose();
     }

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -205,7 +205,7 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
       return;
     }
     data.count -= 1;
-    if (data.count <= 0) {
+    if (data.count == 0 && _livePictureCache.containsKey(data.key)) {
       _livePictureCache.remove(data.key);
       data.pictureInfo.picture.dispose();
     }


### PR DESCRIPTION
Because the cleanup can be entered async, we need to reject in the case where they have already been removed from the live cache