### PR TITLE
make disposal log an error if called more than once

### DIFF
--- a/packages/vector_graphics/lib/src/render_vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphics.dart
@@ -11,17 +11,26 @@ import 'package:flutter/rendering.dart';
 import 'listener.dart';
 import 'debug.dart';
 
+/// The cache key for a rasterized vector graphic.
 @immutable
-class _RasterKey {
-  const _RasterKey(this.assetKey, this.width, this.height);
+class RasterKey {
+  /// Create a new [RasterKey].
+  const RasterKey(this.assetKey, this.width, this.height);
 
+  /// An object that is used to identify the raster data this key will store.
+  ///
+  /// Typically this is the value returned from [BytesLoader.cacheKey].
   final Object assetKey;
+
+  /// The height of this vector graphic raster, in physical pixels.
   final int width;
+
+  /// The width of this vector graphic raster, in physical pixels.
   final int height;
 
   @override
   bool operator ==(Object other) {
-    return other is _RasterKey &&
+    return other is RasterKey &&
         other.assetKey == assetKey &&
         other.width == width &&
         other.height == height;
@@ -31,12 +40,40 @@ class _RasterKey {
   int get hashCode => Object.hash(assetKey, width, height);
 }
 
-class _RasterData {
-  _RasterData(this.image, this.count, this.key);
+/// The cache entry for a rasterized vector graphic.
+class RasterData {
+  /// Create a new [RasterData].
+  RasterData(this.image, this.count, this.key);
 
+  /// The rasterized vector graphic.
   final ui.Image image;
-  final _RasterKey key;
+
+  /// The cache key used to identify this vector graphic.
+  final RasterKey key;
+
+  /// The number of render objects currently using this
+  /// vector graphic raster data.
   int count = 0;
+  bool _disposed = false;
+
+  /// Dispose this raster data, including the attached image.
+  ///
+  /// Will debug print if disposed more than once.
+  void dispose([RenderObject? object]) {
+    if (!_disposed) {
+      image.dispose();
+      _disposed = true;
+    } else {
+      assert(() {
+        debugPrint('Warning: vector graphic image was disposed twice.\n'
+            'The count was $count and the key was $key.\n'
+            'The attached render object was: $object\n'
+            'This is likely a bug in packag:vector_graphics, please file an '
+            'issue at https://github.com/dnfield/vector_graphics .');
+        return true;
+      }());
+    }
+  }
 }
 
 /// For testing only, clear all pending rasters.
@@ -64,10 +101,10 @@ class RenderVectorGraphic extends RenderBox {
     _updateOpacity();
   }
 
-  static final Map<_RasterKey, _RasterData> _liveRasterCache =
-      <_RasterKey, _RasterData>{};
-  static final Map<_RasterKey, Future<_RasterData>> _pendingRasterCache =
-      <_RasterKey, Future<_RasterData>>{};
+  static final Map<RasterKey, RasterData> _liveRasterCache =
+      <RasterKey, RasterData>{};
+  static final Map<RasterKey, Future<RasterData>> _pendingRasterCache =
+      <RasterKey, Future<RasterData>>{};
 
   /// A key that uniquely identifies the [pictureInfo] used for this vg.
   Object get assetKey => _assetKey;
@@ -186,8 +223,8 @@ class RenderVectorGraphic extends RenderBox {
   Future<void>? _pendingRasterUpdate;
   bool _disposed = false;
 
-  static Future<_RasterData> _createRaster(
-      _RasterKey key, double scaleFactor, PictureInfo info) {
+  static Future<RasterData> _createRaster(
+      RasterKey key, double scaleFactor, PictureInfo info) {
     if (_pendingRasterCache.containsKey(key)) {
       return _pendingRasterCache[key]!;
     }
@@ -206,9 +243,9 @@ class RenderVectorGraphic extends RenderBox {
     canvas.drawPicture(info.picture);
     final ui.Picture rasterPicture = recorder.endRecording();
 
-    final Future<_RasterData> pending =
+    final Future<RasterData> pending =
         rasterPicture.toImage(scaledWidth, scaledHeight).then((ui.Image image) {
-      return _RasterData(image, 0, key);
+      return RasterData(image, 0, key);
     });
     _pendingRasterCache[key] = pending;
     pending.whenComplete(() {
@@ -217,14 +254,14 @@ class RenderVectorGraphic extends RenderBox {
     return pending;
   }
 
-  void _maybeReleaseRaster(_RasterData? data) {
+  void _maybeReleaseRaster(RasterData? data) {
     if (data == null) {
       return;
     }
     data.count -= 1;
     if (data.count == 0 && _liveRasterCache.containsKey(data.key)) {
       _liveRasterCache.remove(data.key);
-      data.image.dispose();
+      data.dispose(this);
     }
   }
 
@@ -236,12 +273,12 @@ class RenderVectorGraphic extends RenderBox {
         (pictureInfo.size.width * devicePixelRatio / scale).round();
     final int scaledHeight =
         (pictureInfo.size.height * devicePixelRatio / scale).round();
-    final _RasterKey key = _RasterKey(assetKey, scaledWidth, scaledHeight);
+    final RasterKey key = RasterKey(assetKey, scaledWidth, scaledHeight);
 
     // First check if the raster is available synchronously. This also handles
     // a no-op change that would resolve to an identical picture.
     if (_liveRasterCache.containsKey(key)) {
-      final _RasterData data = _liveRasterCache[key]!;
+      final RasterData data = _liveRasterCache[key]!;
       if (data != _rasterData) {
         _maybeReleaseRaster(_rasterData);
         data.count += 1;
@@ -250,7 +287,7 @@ class RenderVectorGraphic extends RenderBox {
       return null; // immediate update.
     }
     return _createRaster(key, devicePixelRatio / scale, pictureInfo)
-        .then((_RasterData data) {
+        .then((RasterData data) {
       data.count += 1;
       // Ensure this is only added to the live cache once.
       if (data.count == 1) {
@@ -266,7 +303,7 @@ class RenderVectorGraphic extends RenderBox {
     });
   }
 
-  _RasterData? _rasterData;
+  RasterData? _rasterData;
 
   @override
   void attach(covariant PipelineOwner owner) {

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -461,6 +461,23 @@ void main() {
     renderVectorGraphic.dispose();
     expect(opacity._listeners, hasLength(0));
   });
+
+  test('RasterData debug prints on double disposal', () async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    ui.Canvas(recorder);
+    final ui.Image image = await recorder.endRecording().toImage(1, 1);
+    final RasterData data = RasterData(image, 1, const RasterKey('test', 1, 1));
+
+    data.dispose();
+    String? lastMessage;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      lastMessage = message;
+    };
+
+    expect(data.dispose, returnsNormally);
+    expect(lastMessage,
+        contains('Warning: vector graphic image was disposed twice'));
+  });
 }
 
 class FakeCanvas extends Fake implements Canvas {


### PR DESCRIPTION
In theory this problem goes away once we have toImageSync, but I haven't been able to repro locally