### PR TITLE
Codec and runtime support for images

### DIFF
--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -387,20 +387,12 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onImage(int imageId, int format, int width, int height, Uint8List data) {
-    // TODO(jonahwilliams): support other formats.
-    final bool isPng = format == 1;
-
+  void onImage(int imageId, int format, Uint8List data) {
+    assert(format == 0); // Only PNG is supported.
     _pendingImages.add(ui.ImmutableBuffer.fromUint8List(data)
         .then((ui.ImmutableBuffer buffer) async {
-      final ui.ImageDescriptor descriptor = isPng
-          ? await ui.ImageDescriptor.encoded(buffer)
-          : ui.ImageDescriptor.raw(
-              buffer,
-              width: width,
-              height: height,
-              pixelFormat: ui.PixelFormat.rgba8888,
-            );
+      final ui.ImageDescriptor descriptor =
+          await ui.ImageDescriptor.encoded(buffer);
       final ui.Codec codec = await descriptor.instantiateCodec();
       final ui.FrameInfo info = await codec.getNextFrame();
       final ui.Image image = info.image;

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -220,11 +220,12 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
     }
     final Future<_PictureData> result =
         loader.loadBytes(context).then((ByteData data) {
-      final PictureInfo pictureInfo = decodeVectorGraphics(
+      return decodeVectorGraphics(
         data,
         locale: key.locale,
         textDirection: key.textDirection,
       );
+    }).then((PictureInfo pictureInfo) {
       return _PictureData(pictureInfo, 0, key);
     });
     _pendingPictures[key] = result;

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -17,7 +17,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.0
 
-
 # Comment out before publishing
 dependency_overrides:
   vector_graphics_codec:

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^1.0.0
 
+
 # Comment out before publishing
 dependency_overrides:
   vector_graphics_codec:

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -19,11 +19,11 @@ void main() {
     debugClearRasteCaches();
   });
 
-  setUpAll(() {
+  setUpAll(() async {
     final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
     const VectorGraphicsCodec().writeSize(buffer, 50, 50);
 
-    pictureInfo = decodeVectorGraphics(
+    pictureInfo = await decodeVectorGraphics(
       buffer.done(),
       locale: const Locale('fr', 'CH'),
       textDirection: TextDirection.ltr,

--- a/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
+++ b/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
@@ -15,6 +15,40 @@ abstract class ControlPointTypes {
   static const int close = 3;
 }
 
+/// enumeration of the types of image data accepted by [VectorGraphicsCodec.writeImage].
+abstract class ImageFormatTypes {
+  const ImageFormatTypes._();
+
+  /// Raw straight RGBA format.
+  ///
+  /// Unencoded bytes, in RGBA row-primary form with straight alpha, 8 bits per channel.
+  static const int rgba = 0;
+
+  /// PNG format.
+  ///
+  /// A loss-less compression format for images. This format is well suited for
+  /// images with hard edges, such as screenshots or sprites, and images with
+  /// text. Transparency is supported. The PNG format supports images up to
+  /// 2,147,483,647 pixels in either dimension, though in practice available
+  /// memory provides a more immediate limitation on maximum image size.
+  ///
+  /// PNG images normally use the `.png` file extension and the `image/png` MIME
+  /// type.
+  ///
+  /// See also:
+  ///
+  ///  * <https://en.wikipedia.org/wiki/Portable_Network_Graphics>, the Wikipedia page on PNG.
+  ///  * <https://tools.ietf.org/rfc/rfc2083.txt>, the PNG standard.
+  static const int png = 1;
+}
+
+class DecodeResponse {
+  const DecodeResponse(this.complete, this._buffer);
+
+  final bool complete;
+  final _ReadBuffer? _buffer;
+}
+
 /// The [VectorGraphicsCodec] provides support for both encoding and
 /// decoding the vector_graphics binary format.
 class VectorGraphicsCodec {
@@ -45,6 +79,9 @@ class VectorGraphicsCodec {
   static const int _maskTag = 43;
   static const int _drawTextTag = 44;
   static const int _textConfigTag = 45;
+  static const int _imageConfigTag = 46;
+  static const int _drawImageTag = 47;
+  static const int _beginCommandsTag = 48;
 
   static const int _version = 1;
   static const int _magicNumber = 0x00882d62;
@@ -56,25 +93,38 @@ class VectorGraphicsCodec {
   /// a dart:ui Picture object should implement [VectorGraphicsCodecListener].
   ///
   /// Throws a [StateError] If the message is invalid.
-  void decode(ByteData data, VectorGraphicsCodecListener? listener) {
-    final _ReadBuffer buffer = _ReadBuffer(data);
-    if (data.lengthInBytes < 5) {
-      throw StateError(
-          'The provided data was not a vector_graphics binary asset.');
+  DecodeResponse decode(ByteData data, VectorGraphicsCodecListener? listener,
+      {DecodeResponse? response}) {
+    final _ReadBuffer buffer;
+    if (response == null) {
+      buffer = _ReadBuffer(data);
+      if (data.lengthInBytes < 5) {
+        throw StateError(
+            'The provided data was not a vector_graphics binary asset.');
+      }
+      final int magicNumber = buffer.getUint32();
+      if (magicNumber != _magicNumber) {
+        throw StateError(
+            'The provided data was not a vector_graphics binary asset.');
+      }
+      final int version = buffer.getUint8();
+      if (version != _version) {
+        throw StateError(
+            'The provided data does not match the currently supported version.');
+      }
+    } else {
+      buffer = response._buffer!;
     }
-    final int magicNumber = buffer.getUint32();
-    if (magicNumber != _magicNumber) {
-      throw StateError(
-          'The provided data was not a vector_graphics binary asset.');
-    }
-    final int version = buffer.getUint8();
-    if (version != _version) {
-      throw StateError(
-          'The provided data does not match the currently supported version.');
-    }
+
+    bool readImage = false;
     while (buffer.hasRemaining) {
       final int type = buffer.getUint8();
       switch (type) {
+        case _beginCommandsTag:
+          if (readImage) {
+            return DecodeResponse(false, buffer);
+          }
+          continue;
         case _linearGradientTag:
           _readLinearGradient(buffer, listener);
           continue;
@@ -117,10 +167,18 @@ class VectorGraphicsCodec {
         case _drawTextTag:
           _readDrawText(buffer, listener);
           continue;
+        case _imageConfigTag:
+          readImage = true;
+          _readImageConfig(buffer, listener);
+          continue;
+        case _drawImageTag:
+          _readDrawImage(buffer, listener);
+          continue;
         default:
           throw StateError('Unknown type tag $type');
       }
     }
+    return const DecodeResponse(true, null);
   }
 
   /// Encode the dimensions of the vector graphic.
@@ -148,6 +206,9 @@ class VectorGraphicsCodec {
     int pathId,
     int paintId,
   ) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
+
     buffer._putUint8(_drawPathTag);
     buffer._putUint16(pathId);
     buffer._putUint16(paintId);
@@ -163,6 +224,7 @@ class VectorGraphicsCodec {
     int? paintId,
   ) {
     buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
 
     // Type Tag
     // Vertex Length
@@ -438,6 +500,9 @@ class VectorGraphicsCodec {
   /// See also:
   ///   * [Canvas.saveLayer]
   void writeSaveLayer(VectorGraphicsBuffer buffer, int paint) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
+
     buffer._putUint8(_saveLayerTag);
     buffer._putUint16(paint);
   }
@@ -448,6 +513,8 @@ class VectorGraphicsCodec {
   /// See also:
   ///   * [Canvas.restore]
   void writeRestoreLayer(VectorGraphicsBuffer buffer) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
     buffer._putUint8(_restoreTag);
   }
 
@@ -500,17 +567,23 @@ class VectorGraphicsCodec {
     int textId,
     int paintId,
   ) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
     buffer._putUint8(_drawTextTag);
     buffer._putUint16(textId);
     buffer._putUint16(paintId);
   }
 
   void writeClipPath(VectorGraphicsBuffer buffer, int path) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
     buffer._putUint8(_clipPathTag);
     buffer._putUint16(path);
   }
 
   void writeMask(VectorGraphicsBuffer buffer) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
     buffer._putUint8(_maskTag);
   }
 
@@ -541,6 +614,58 @@ class VectorGraphicsCodec {
     buffer._putUint32(controlPoints.length);
     buffer._putFloat32List(controlPoints);
     return id;
+  }
+
+  /// Write an image to the [buffer], returning the identifier
+  /// assigned to it.
+  ///
+  /// The [width] and [height] argument should be the width and
+  /// height of the image and must be non-negative and greater than 0.
+  ///
+  /// The [data] argument should be the image data encoded according
+  /// to the [format] argument.
+  int writeImage(
+    VectorGraphicsBuffer buffer,
+    int width,
+    int height,
+    int format,
+    Uint8List data,
+  ) {
+    buffer._checkPhase(_CurrentSection.images);
+    assert(buffer._nextImageId < kMaxId);
+    assert(width > 0 && height > 0);
+
+    final int id = buffer._nextImageId;
+    buffer._nextImageId += 1;
+
+    buffer._putUint8(_imageConfigTag);
+    buffer._putUint16(id);
+    buffer._putUint8(format);
+    buffer._putUint32(width);
+    buffer._putUint32(height);
+    buffer._putUint32(data.length);
+    buffer._putUint8List(data);
+    return id;
+  }
+
+  void writeDrawImage(
+    VectorGraphicsBuffer buffer,
+    int imageId,
+    double x,
+    double y,
+    int width,
+    int height,
+  ) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
+    assert(width > 0 && height > 0);
+
+    buffer._putUint8(_drawImageTag);
+    buffer._putUint16(imageId);
+    buffer._putFloat32(x);
+    buffer._putFloat32(y);
+    buffer._putUint32(width);
+    buffer._putUint32(height);
   }
 
   void _readPath(
@@ -659,6 +784,28 @@ class VectorGraphicsCodec {
     final int textId = buffer.getUint16();
     final int paintId = buffer.getUint16();
     listener?.onDrawText(textId, paintId);
+  }
+
+  void _readImageConfig(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+    final int id = buffer.getUint16();
+    final int format = buffer.getUint8();
+    final int width = buffer.getUint32();
+    final int height = buffer.getUint32();
+    final int dataLength = buffer.getUint32();
+    final Uint8List data = buffer.getUint8List(dataLength);
+    listener?.onImage(id, format, width, height, data);
+  }
+
+  void _readDrawImage(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+    final int id = buffer.getUint16();
+    final double x = buffer.getFloat32();
+    final double y = buffer.getFloat32();
+    final int width = buffer.getUint32();
+    final int height = buffer.getUint32();
+
+    listener?.onDrawImage(id, x, y, width, height);
   }
 }
 
@@ -781,10 +928,29 @@ abstract class VectorGraphicsCodecListener {
     int textId,
     int paintId,
   );
+
+  /// An image has been decoded.
+  void onImage(
+    int imageId,
+    int format,
+    int width,
+    int height,
+    Uint8List data,
+  );
+
+  /// An image should be drawn at the provided location.
+  void onDrawImage(
+    int imageId,
+    double x,
+    double y,
+    int width,
+    int height,
+  );
 }
 
 enum _CurrentSection {
   size,
+  images,
   shaders,
   paints,
   paths,
@@ -828,11 +994,25 @@ class VectorGraphicsBuffer {
   /// The next text id to be used.
   int _nextTextId = 0;
 
+  /// The next image id to be used.
+  int _nextImageId = 0;
+
+  bool _addedCommandTag = false;
+
   /// The current decoding phase.
   ///
   /// Objects must be written in the correct order, the same as the
   /// enum order.
   _CurrentSection _decodePhase = _CurrentSection.size;
+
+  /// Add a commands tag section if it is not already present.
+  void _addCommandsTag() {
+    if (_addedCommandTag) {
+      return;
+    }
+    _putUint8(VectorGraphicsCodec._beginCommandsTag);
+    _addedCommandTag = true;
+  }
 
   void _checkPhase(_CurrentSection expected) {
     if (_decodePhase.index > expected.index) {

--- a/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
+++ b/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
@@ -16,14 +16,9 @@ abstract class ControlPointTypes {
 }
 
 /// enumeration of the types of image data accepted by [VectorGraphicsCodec.writeImage].
+///
+/// Currently only PNG encoding is supported.
 abstract class ImageFormatTypes {
-  const ImageFormatTypes._();
-
-  /// Raw straight RGBA format.
-  ///
-  /// Unencoded bytes, in RGBA row-primary form with straight alpha, 8 bits per channel.
-  static const int rgba = 0;
-
   /// PNG format.
   ///
   /// A loss-less compression format for images. This format is well suited for
@@ -39,7 +34,7 @@ abstract class ImageFormatTypes {
   ///
   ///  * <https://en.wikipedia.org/wiki/Portable_Network_Graphics>, the Wikipedia page on PNG.
   ///  * <https://tools.ietf.org/rfc/rfc2083.txt>, the PNG standard.
-  static const int png = 1;
+  static const int png = 0;
 }
 
 class DecodeResponse {
@@ -619,21 +614,16 @@ class VectorGraphicsCodec {
   /// Write an image to the [buffer], returning the identifier
   /// assigned to it.
   ///
-  /// The [width] and [height] argument should be the width and
-  /// height of the image and must be non-negative and greater than 0.
-  ///
   /// The [data] argument should be the image data encoded according
-  /// to the [format] argument.
+  /// to the [format] argument. Currently only PNG is supported.
   int writeImage(
     VectorGraphicsBuffer buffer,
-    int width,
-    int height,
     int format,
     Uint8List data,
   ) {
     buffer._checkPhase(_CurrentSection.images);
     assert(buffer._nextImageId < kMaxId);
-    assert(width > 0 && height > 0);
+    assert(format == 0);
 
     final int id = buffer._nextImageId;
     buffer._nextImageId += 1;
@@ -641,8 +631,6 @@ class VectorGraphicsCodec {
     buffer._putUint8(_imageConfigTag);
     buffer._putUint16(id);
     buffer._putUint8(format);
-    buffer._putUint32(width);
-    buffer._putUint32(height);
     buffer._putUint32(data.length);
     buffer._putUint8List(data);
     return id;
@@ -790,11 +778,9 @@ class VectorGraphicsCodec {
       _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int id = buffer.getUint16();
     final int format = buffer.getUint8();
-    final int width = buffer.getUint32();
-    final int height = buffer.getUint32();
     final int dataLength = buffer.getUint32();
     final Uint8List data = buffer.getUint8List(dataLength);
-    listener?.onImage(id, format, width, height, data);
+    listener?.onImage(id, format, data);
   }
 
   void _readDrawImage(
@@ -933,8 +919,6 @@ abstract class VectorGraphicsCodecListener {
   void onImage(
     int imageId,
     int format,
-    int width,
-    int height,
     Uint8List data,
   );
 

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -638,15 +638,15 @@ void main() {
     final buffer = VectorGraphicsBuffer();
     final TestListener listener = TestListener();
 
-    final id = codec.writeImage(
-        buffer, 20, 30, 0, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
+    final id =
+        codec.writeImage(buffer, 20, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
     codec.writeDrawImage(buffer, id, 1, 2, 100, 100);
     final ByteData data = buffer.done();
     final DecodeResponse response = codec.decode(data, listener);
 
     expect(response.complete, false);
     expect(listener.commands, [
-      OnImage(id, 0, 20, 30, [0, 1, 3, 4, 5]),
+      OnImage(id, 0, [0, 1, 3, 4, 5]),
     ]);
 
     final DecodeResponse nextResponse =
@@ -654,7 +654,7 @@ void main() {
 
     expect(nextResponse.complete, true);
     expect(listener.commands, [
-      OnImage(id, 0, 20, 30, [0, 1, 3, 4, 5]),
+      OnImage(id, 0, [0, 1, 3, 4, 5]),
       OnDrawImage(id, 1, 2, 100, 100),
     ]);
   });
@@ -663,8 +663,8 @@ void main() {
     final buffer = VectorGraphicsBuffer();
     final TestListener listener = TestListener();
 
-    final imageId = codec.writeImage(
-        buffer, 20, 30, 0, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
+    final imageId =
+        codec.writeImage(buffer, 20, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
     final int shaderId = codec.writeLinearGradient(
       buffer,
       fromX: 0,
@@ -701,8 +701,6 @@ void main() {
       OnImage(
         imageId,
         0,
-        20,
-        30,
         <int>[0, 1, 3, 4, 5],
       ),
       OnLinearGradient(
@@ -751,8 +749,6 @@ void main() {
       OnImage(
         imageId,
         0,
-        20,
-        30,
         <int>[0, 1, 3, 4, 5],
       ),
       OnLinearGradient(
@@ -976,12 +972,10 @@ class TestListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onImage(int imageId, int format, int width, int height, Uint8List data) {
+  void onImage(int imageId, int format, Uint8List data) {
     commands.add(OnImage(
       imageId,
       format,
-      width,
-      height,
       data,
     ));
   }
@@ -1406,29 +1400,24 @@ class OnDrawText {
 }
 
 class OnImage {
-  const OnImage(this.id, this.format, this.width, this.height, this.data);
+  const OnImage(this.id, this.format, this.data);
 
   final int id;
   final int format;
-  final int width;
-  final int height;
   final List<int> data;
 
   @override
-  int get hashCode => Object.hash(id, format, width, height, data);
+  int get hashCode => Object.hash(id, format, data);
 
   @override
   bool operator ==(Object other) =>
       other is OnImage &&
       other.id == id &&
       other.format == format &&
-      other.width == width &&
-      other.height == height &&
       _listEquals(other.data, data);
 
   @override
-  String toString() =>
-      'OnImage($id, $format, $width, $height, data:${data.length} bytes)';
+  String toString() => 'OnImage($id, $format, data:${data.length} bytes)';
 }
 
 class OnDrawImage {

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -639,7 +639,7 @@ void main() {
     final TestListener listener = TestListener();
 
     final id =
-        codec.writeImage(buffer, 20, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
+        codec.writeImage(buffer, 0, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
     codec.writeDrawImage(buffer, id, 1, 2, 100, 100);
     final ByteData data = buffer.done();
     final DecodeResponse response = codec.decode(data, listener);
@@ -664,7 +664,7 @@ void main() {
     final TestListener listener = TestListener();
 
     final imageId =
-        codec.writeImage(buffer, 20, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
+        codec.writeImage(buffer, 0, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
     final int shaderId = codec.writeLinearGradient(
       buffer,
       fromX: 0,

--- a/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
+++ b/packages/vector_graphics_codec/test/vector_graphics_codec_test.dart
@@ -658,6 +658,145 @@ void main() {
       OnDrawImage(id, 1, 2, 100, 100),
     ]);
   });
+
+  test('Basic message encode and decode with shaded path and image', () {
+    final buffer = VectorGraphicsBuffer();
+    final TestListener listener = TestListener();
+
+    final imageId = codec.writeImage(
+        buffer, 20, 30, 0, Uint8List.fromList(<int>[0, 1, 3, 4, 5]));
+    final int shaderId = codec.writeLinearGradient(
+      buffer,
+      fromX: 0,
+      fromY: 0,
+      toX: 1,
+      toY: 1,
+      colors: Int32List.fromList([0, 1]),
+      offsets: Float32List.fromList([0, 1]),
+      tileMode: 1,
+    );
+    final int fillId = codec.writeFill(buffer, 23, 0, shaderId);
+    final int strokeId =
+        codec.writeStroke(buffer, 44, 1, 2, 3, 4.0, 6.0, shaderId);
+    final int pathId = codec.writePath(
+      buffer,
+      Uint8List.fromList(<int>[
+        ControlPointTypes.moveTo,
+        ControlPointTypes.lineTo,
+        ControlPointTypes.close
+      ]),
+      Float32List.fromList(<double>[1, 2, 2, 3]),
+      0,
+    );
+    codec.writeDrawPath(buffer, pathId, fillId);
+    codec.writeDrawPath(buffer, pathId, strokeId);
+    codec.writeDrawImage(buffer, imageId, 1, 2, 100, 100);
+
+    final ByteData data = buffer.done();
+
+    DecodeResponse response = codec.decode(data, listener);
+
+    expect(response.complete, false);
+    expect(listener.commands, [
+      OnImage(
+        imageId,
+        0,
+        20,
+        30,
+        <int>[0, 1, 3, 4, 5],
+      ),
+      OnLinearGradient(
+        fromX: 0,
+        fromY: 0,
+        toX: 1,
+        toY: 1,
+        colors: Int32List.fromList([0, 1]),
+        offsets: Float32List.fromList([0, 1]),
+        tileMode: 1,
+        id: shaderId,
+      ),
+      OnPaintObject(
+        color: 23,
+        strokeCap: null,
+        strokeJoin: null,
+        blendMode: 0,
+        strokeMiterLimit: null,
+        strokeWidth: null,
+        paintStyle: 0,
+        id: fillId,
+        shaderId: shaderId,
+      ),
+      OnPaintObject(
+        color: 44,
+        strokeCap: 1,
+        strokeJoin: 2,
+        blendMode: 3,
+        strokeMiterLimit: 4.0,
+        strokeWidth: 6.0,
+        paintStyle: 1,
+        id: strokeId,
+        shaderId: shaderId,
+      ),
+      OnPathStart(pathId, 0),
+      const OnPathMoveTo(1, 2),
+      const OnPathLineTo(2, 3),
+      const OnPathClose(),
+      const OnPathFinished(),
+    ]);
+
+    response = codec.decode(data, listener, response: response);
+
+    expect(response.complete, true);
+    expect(listener.commands, [
+      OnImage(
+        imageId,
+        0,
+        20,
+        30,
+        <int>[0, 1, 3, 4, 5],
+      ),
+      OnLinearGradient(
+        fromX: 0,
+        fromY: 0,
+        toX: 1,
+        toY: 1,
+        colors: Int32List.fromList([0, 1]),
+        offsets: Float32List.fromList([0, 1]),
+        tileMode: 1,
+        id: shaderId,
+      ),
+      OnPaintObject(
+        color: 23,
+        strokeCap: null,
+        strokeJoin: null,
+        blendMode: 0,
+        strokeMiterLimit: null,
+        strokeWidth: null,
+        paintStyle: 0,
+        id: fillId,
+        shaderId: shaderId,
+      ),
+      OnPaintObject(
+        color: 44,
+        strokeCap: 1,
+        strokeJoin: 2,
+        blendMode: 3,
+        strokeMiterLimit: 4.0,
+        strokeWidth: 6.0,
+        paintStyle: 1,
+        id: strokeId,
+        shaderId: shaderId,
+      ),
+      OnPathStart(pathId, 0),
+      const OnPathMoveTo(1, 2),
+      const OnPathLineTo(2, 3),
+      const OnPathClose(),
+      const OnPathFinished(),
+      OnDrawPath(pathId, fillId),
+      OnDrawPath(pathId, strokeId),
+      OnDrawImage(imageId, 1, 2, 100, 100),
+    ]);
+  });
 }
 
 class TestListener extends VectorGraphicsCodecListener {

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -363,6 +363,16 @@ class TestListener extends VectorGraphicsCodecListener {
   void onDrawText(int textId, int paintId) {
     commands.add(OnDrawText(textId, paintId));
   }
+
+  @override
+  void onDrawImage(int imageId, double x, double y, int width, int height) {
+    commands.add(OnDrawImage(imageId, x, y, width, height));
+  }
+
+  @override
+  void onImage(int imageId, int format, int width, int height, Uint8List data) {
+    commands.add(OnImage(imageId, format, width, height, data));
+  }
 }
 
 class OnMask {
@@ -776,6 +786,58 @@ class OnDrawText {
 
   @override
   String toString() => 'OnDrawText($textId, $paintId)';
+}
+
+class OnImage {
+  const OnImage(this.id, this.format, this.width, this.height, this.data);
+
+  final int id;
+  final int format;
+  final int width;
+  final int height;
+  final List<int> data;
+
+  @override
+  int get hashCode => Object.hash(id, format, width, height, data);
+
+  @override
+  bool operator ==(Object other) =>
+      other is OnImage &&
+      other.id == id &&
+      other.format == format &&
+      other.width == width &&
+      other.height == height &&
+      _listEquals(other.data, data);
+
+  @override
+  String toString() =>
+      'OnImage($id, $format, $width, $height, data:${data.length} bytes)';
+}
+
+class OnDrawImage {
+  const OnDrawImage(this.id, this.x, this.y, this.width, this.height);
+
+  final int id;
+  final double x;
+  final double y;
+  final int width;
+  final int height;
+
+  @override
+  int get hashCode => Object.hash(id, x, y, width, height);
+
+  @override
+  bool operator ==(Object other) {
+    return other is OnDrawImage &&
+        other.id == id &&
+        other.x == x &&
+        other.y == y &&
+        other.width == width &&
+        other.height == height;
+  }
+
+  @override
+  String toString() => 'OnDrawImage($id, $x, $y, $width, $height)';
 }
 
 bool _listEquals<E>(List<E>? left, List<E>? right) {

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -370,8 +370,8 @@ class TestListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onImage(int imageId, int format, int width, int height, Uint8List data) {
-    commands.add(OnImage(imageId, format, width, height, data));
+  void onImage(int imageId, int format, Uint8List data) {
+    commands.add(OnImage(imageId, format, data));
   }
 }
 
@@ -789,29 +789,24 @@ class OnDrawText {
 }
 
 class OnImage {
-  const OnImage(this.id, this.format, this.width, this.height, this.data);
+  const OnImage(this.id, this.format, this.data);
 
   final int id;
   final int format;
-  final int width;
-  final int height;
   final List<int> data;
 
   @override
-  int get hashCode => Object.hash(id, format, width, height, data);
+  int get hashCode => Object.hash(id, format, data);
 
   @override
   bool operator ==(Object other) =>
       other is OnImage &&
       other.id == id &&
       other.format == format &&
-      other.width == width &&
-      other.height == height &&
       _listEquals(other.data, data);
 
   @override
-  String toString() =>
-      'OnImage($id, $format, $width, $height, data:${data.length} bytes)';
+  String toString() => 'OnImage($id, $format, data:${data.length} bytes)';
 }
 
 class OnDrawImage {


### PR DESCRIPTION
First part of adding support for the `<image>` tag - add an encoding and decoding format.

To avoid making the main decoding loop async, we instead break it into two phases - pre-command and post command. During the precommand phase, we can decode images, paints, shaders, et cetera. Image decoding is kicked off by the listener but not awaited. Then when the decoder hits the first command, it checks if it encountered any image tags. If so, it returns an object that allows the decode call to resume for the current position. The caller is then repsonsible for ensuring that all images are decoded before invoking the decode call and passing in the same object.

This does not add compiler support yet.

https://github.com/dnfield/vector_graphics/issues/84