### PR TITLE
Make examples work again

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -52,6 +52,7 @@ class NetworkSvgLoader extends BytesLoader {
         debugName: svgUrl,
         enableClippingOptimizer: false,
         enableMaskingOptimizer: false,
+        enableOverdrawOptimizer: false,
       );
       task.finish();
       // sendAndExit will make sure this isn't copied.

--- a/packages/vector_graphics/example/lib/svg_string.dart
+++ b/packages/vector_graphics/example/lib/svg_string.dart
@@ -51,8 +51,13 @@ class _MyAppState extends State<MyApp> {
     }
     _debounce = Timer(const Duration(milliseconds: 250), () {
       compute((String svg) async {
-        final Uint8List compiledBytes =
-            await encodeSvg(xml: svg, debugName: '<string>');
+        final Uint8List compiledBytes = await encodeSvg(
+          xml: svg,
+          debugName: '<string>',
+          enableClippingOptimizer: false,
+          enableMaskingOptimizer: false,
+          enableOverdrawOptimizer: false,
+        );
         return compiledBytes.buffer.asByteData();
       }, text, debugLabel: 'Load Bytes')
           .then((ByteData data) {


### PR DESCRIPTION
The path_ops library isn't available when using the parser in the example apps right now.