### PR TITLE
make vector_graphics_compiler compile on the web again

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
@@ -13,40 +13,6 @@ import 'path_ops.dart';
 final ffi.DynamicLibrary _dylib = ffi.DynamicLibrary.open(_dylibPath);
 late final String _dylibPath;
 
-/// A path proxy that can print the SVG path-data representation of this path.
-class SvgPathProxy implements PathProxy {
-  final StringBuffer _buffer = StringBuffer();
-
-  @override
-  void reset() {
-    _buffer.clear();
-  }
-
-  @override
-  void close() {
-    _buffer.write('Z');
-  }
-
-  @override
-  void cubicTo(
-      double x1, double y1, double x2, double y2, double x3, double y3) {
-    _buffer.write('C$x1,$y1 $x2,$y2 $x3,$y3');
-  }
-
-  @override
-  void lineTo(double x, double y) {
-    _buffer.write('L$x,$y');
-  }
-
-  @override
-  void moveTo(double x, double y) {
-    _buffer.write('M$x,$y');
-  }
-
-  @override
-  String toString() => _buffer.toString();
-}
-
 /// Creates a path object to operate on.
 ///
 /// First, build up the path contours with the [moveTo], [lineTo], [cubicTo],

--- a/packages/vector_graphics_compiler/lib/src/svg/_path_ops_unsupported.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_path_ops_unsupported.dart
@@ -2,8 +2,87 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
+import 'path_ops.dart';
+
 /// Whether or not tesselation should be used.
 bool get isPathOpsInitialized => false;
 
 /// Initialize the libpathops dynamic library.
 void initializeLibPathOps(String path) {}
+
+/// Creates a path object to operate on.
+class Path implements PathProxy {
+  /// Creates an empty path object with the specified fill type.
+  Path([this.fillType = FillType.nonZero]);
+
+  /// Creates a copy of this path.
+  factory Path.from(Path other) {
+    final Path result = Path(other.fillType);
+    other.replay(result);
+    return result;
+  }
+
+  /// The [FillType] of this path.
+  final FillType fillType;
+
+  /// Makes the appropriate calls using [verbs] and [points] to replay this path
+  /// on [proxy].
+  ///
+  /// Calls [PathProxy.reset] first if [reset] is true.
+  void replay(PathProxy proxy, {bool reset = true}) {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  @override
+  void close() {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  @override
+  void cubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3) {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  @override
+  void lineTo(double x, double y) {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  @override
+  void moveTo(double x, double y) {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  @override
+  void reset() {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  /// Applies the operation described by [op] to this path using [other].
+  Path applyOp(Path other, PathOp op) {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  /// Retrieves PathVerbs.
+  Iterable<PathVerb> get verbs {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  /// The list of points to use with [verbs].
+  ///
+  /// Each verb uses a specific number of points, specified by the
+  /// [pointsPerVerb] map.
+  Float32List get points {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+
+  /// Releases native resources.
+  ///
+  /// After calling dispose, this class must not be used again.
+  void dispose() {
+    throw UnsupportedError('PathOps not supported on the web');
+  }
+}

--- a/packages/vector_graphics_compiler/lib/src/svg/path_ops.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/path_ops.dart
@@ -6,7 +6,7 @@
 
 import '_path_ops_unsupported.dart' if (dart.library.ffi) '_path_ops_ffi.dart'
     as impl;
-export '_path_ops_ffi.dart';
+export '_path_ops_unsupported.dart' if (dart.library.ffi) '_path_ops_ffi.dart';
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names
 
@@ -88,4 +88,38 @@ abstract class PathProxy {
 
   /// Called by [Path.replay] to indicate that a new path is being played.
   void reset() {}
+}
+
+/// A path proxy that can print the SVG path-data representation of this path.
+class SvgPathProxy implements PathProxy {
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  void reset() {
+    _buffer.clear();
+  }
+
+  @override
+  void close() {
+    _buffer.write('Z');
+  }
+
+  @override
+  void cubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3) {
+    _buffer.write('C$x1,$y1 $x2,$y2 $x3,$y3');
+  }
+
+  @override
+  void lineTo(double x, double y) {
+    _buffer.write('L$x,$y');
+  }
+
+  @override
+  void moveTo(double x, double y) {
+    _buffer.write('M$x,$y');
+  }
+
+  @override
+  String toString() => _buffer.toString();
 }


### PR DESCRIPTION
Fixes compilation error when building the vector graphics example app targeting chrome.