### PR TITLE
move native library tests into optimizer test suites

### DIFF
--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -33,11 +33,6 @@ class TestBytesLoader extends BytesLoader {
 }
 
 void main() {
-  setUpAll(() {
-    if (!initializePathOpsFromFlutterCache()) {
-      fail('error in setup');
-    }
-  });
 
   testWidgets('Can endcode and decode simple SVGs with no errors',
       (WidgetTester tester) async {
@@ -46,6 +41,9 @@ void main() {
         xml: svg,
         debugName: 'test.svg',
         warningsAsErrors: true,
+        enableClippingOptimizer: false,
+        enableMaskingOptimizer: false,
+        enableOverdrawOptimizer: false,
       );
 
       await tester.pumpWidget(Center(
@@ -67,7 +65,13 @@ void main() {
 
     expect(
         () => encodeSvg(
-            xml: svgInlineImage, debugName: 'test.svg', warningsAsErrors: true),
+              xml: svgInlineImage,
+              debugName: 'test.svg',
+              warningsAsErrors: true,
+              enableClippingOptimizer: false,
+              enableMaskingOptimizer: false,
+              enableOverdrawOptimizer: false,
+            ),
         throwsA(isA<UnimplementedError>()));
   });
 
@@ -86,7 +90,13 @@ void main() {
 </svg>
 ''';
 
-    final Uint8List bytes = await encodeSvg(xml: svg, debugName: 'test');
+    final Uint8List bytes = await encodeSvg(
+      xml: svg,
+      debugName: 'test',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     const VectorGraphicsCodec codec = VectorGraphicsCodec();
     final TestListener listener = TestListener();
     codec.decode(bytes.buffer.asByteData(), listener);
@@ -144,7 +154,13 @@ void main() {
 </svg>
 ''';
 
-    final Uint8List bytes = await encodeSvg(xml: svg, debugName: 'test');
+    final Uint8List bytes = await encodeSvg(
+      xml: svg,
+      debugName: 'test',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     const VectorGraphicsCodec codec = VectorGraphicsCodec();
     final TestListener listener = TestListener();
     codec.decode(bytes.buffer.asByteData(), listener);
@@ -221,7 +237,13 @@ void main() {
 </svg>
 ''';
 
-    final Uint8List bytes = await encodeSvg(xml: svg, debugName: 'test');
+    final Uint8List bytes = await encodeSvg(
+      xml: svg,
+      debugName: 'test',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     const VectorGraphicsCodec codec = VectorGraphicsCodec();
     final TestListener listener = TestListener();
     final ByteData data = bytes.buffer.asByteData();
@@ -244,7 +266,13 @@ void main() {
 </svg>
 ''';
 
-    final Uint8List bytes = await encodeSvg(xml: svg, debugName: 'test');
+    final Uint8List bytes = await encodeSvg(
+      xml: svg,
+      debugName: 'test',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     const VectorGraphicsCodec codec = VectorGraphicsCodec();
     final TestListener listener = TestListener();
     final ByteData data = bytes.buffer.asByteData();
@@ -267,7 +295,13 @@ void main() {
 </svg>
 ''';
 
-    final Uint8List bytes = await encodeSvg(xml: svg, debugName: 'test');
+    final Uint8List bytes = await encodeSvg(
+      xml: svg,
+      debugName: 'test',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     const VectorGraphicsCodec codec = VectorGraphicsCodec();
     final TestListener listener = TestListener();
     final ByteData data = bytes.buffer.asByteData();

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -33,7 +33,6 @@ class TestBytesLoader extends BytesLoader {
 }
 
 void main() {
-
   testWidgets('Can endcode and decode simple SVGs with no errors',
       (WidgetTester tester) async {
     for (final String svg in allSvgTestStrings) {

--- a/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
@@ -10,23 +10,13 @@ import 'package:vector_graphics_compiler/src/svg/resolver.dart';
 import 'package:vector_graphics_compiler/src/svg/parser.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 
+import 'helpers.dart';
+import 'test_svg_strings.dart';
+
 Future<Node> parseAndResolve(String source) async {
   final Node node = await parseToNodeTree(source);
   final ResolvingVisitor visitor = ResolvingVisitor();
   return node.accept(visitor, AffineMatrix.identity);
-}
-
-List<T> queryChildren<T extends Node>(Node node) {
-  final List<T> children = <T>[];
-  void visitor(Node child) {
-    if (child is T) {
-      children.add(child);
-    }
-    child.visitChildren(visitor);
-  }
-
-  node.visitChildren(visitor);
-  return children;
 }
 
 const String xmlString =
@@ -135,5 +125,44 @@ void main() {
 
     expect(pathNodesOld.length, pathNodesNew.length);
     expect(parentNodesOld.length, parentNodesNew.length);
+  });
+
+  test('Masks on groups', () async {
+    final VectorInstructions instructions =
+        await parse(groupMask, enableMaskingOptimizer: false);
+    expect(instructions.paths, <Path>[
+      parseSvgPathData(
+              'M 17.438 8.438 C 17.748 8.438 18 8.69 18 9 L 18 16.313 C 17.99834725871 17.24440923535 17.24341005121 17.99889920517 16.312 18 L 1.688 18 C 0.75620021668 17.99889792932 0.00110207068 17.24379978332 0 16.312 L 0 9 C 0.01271270943 8.69855860173 0.26079065383 8.46072235233 0.5625 8.46072235233 C 0.86420934617 8.46072235233 1.11228729057 8.69855860173 1.125 9 L 1.125 16.313 C 1.125 16.622 1.377 16.875 1.688 16.875 L 16.312 16.875 C 16.622 16.875 16.875 16.622 16.875 16.312 L 16.875 9 C 16.875 8.69 17.127 8.437 17.438 8.437 Z M 9 0 C 9.169 0 9.316 0.079 9.418 0.196 L 9.423 0.192 L 13.361 4.692 C 13.443 4.795 13.5 4.921 13.5 5.062 C 13.5 5.373 13.248 5.625 12.937 5.625 C 12.77572417052 5.6238681172 12.62300981305 5.55226042805 12.519 5.429 L 12.514 5.433 L 9.563 2.06 L 9.563 11.812 C 9.56299999183 12.12293630838 9.31093630838 12.3749999852 9 12.3749999852 C 8.68906369162 12.3749999852 8.43700000817 12.12293630838 8.437 11.812 L 8.437 2.06 L 5.486 5.433 C 5.37775998399 5.5529360201 5.22453705399 5.62248401669 5.063 5.625 C 4.75206368585 5.625 4.5 5.37293631415 4.5 5.062 C 4.5 4.921 4.557 4.795 4.644 4.696 L 4.639 4.692 L 8.577 0.192 C 8.68524001601 0.0720639799 8.83846294601 0.00251598331 9 0 Z',
+              PathFillType.evenOdd)
+          .transformed(const AffineMatrix(0.00000000000000006123233995736766, 1,
+              -1, 0.00000000000000006123233995736766, 21, 3)),
+      parseSvgPathData(
+              'M -3 -3 L 21 -3 L 21 21 L -3 21 Z', PathFillType.evenOdd)
+          .transformed(const AffineMatrix(1, 0, 0, 1, 3, 3)),
+      parseSvgPathData(
+              'M 17.438 8.438 C 17.748 8.438 18 8.69 18 9 L 18 16.313 C 17.99834725871 17.24440923535 17.24341005121 17.99889920517 16.312 18 L 1.688 18 C 0.75620021668 17.99889792932 0.00110207068 17.24379978332 0 16.312 L 0 9 C 0.01271270943 8.69855860173 0.26079065383 8.46072235233 0.5625 8.46072235233 C 0.86420934617 8.46072235233 1.11228729057 8.69855860173 1.125 9 L 1.125 16.313 C 1.125 16.622 1.377 16.875 1.688 16.875 L 16.312 16.875 C 16.622 16.875 16.875 16.622 16.875 16.312 L 16.875 9 C 16.875 8.69 17.127 8.437 17.438 8.437 Z M 9 0 C 9.169 0 9.316 0.079 9.418 0.196 L 9.423 0.192 L 13.361 4.692 C 13.443 4.795 13.5 4.921 13.5 5.062 C 13.5 5.373 13.248 5.625 12.937 5.625 C 12.77572417052 5.6238681172 12.62300981305 5.55226042805 12.519 5.429 L 12.514 5.433 L 9.563 2.06 L 9.563 11.812 C 9.56299999183 12.12293630838 9.31093630838 12.3749999852 9 12.3749999852 C 8.68906369162 12.3749999852 8.43700000817 12.12293630838 8.437 11.812 L 8.437 2.06 L 5.486 5.433 C 5.37775998399 5.5529360201 5.22453705399 5.62248401669 5.063 5.625 C 4.75206368585 5.625 4.5 5.37293631415 4.5 5.062 C 4.5 4.921 4.557 4.795 4.644 4.696 L 4.639 4.692 L 8.577 0.192 C 8.68524001601 0.0720639799 8.83846294601 0.00251598331 9 0 Z',
+              PathFillType.evenOdd)
+          .transformed(const AffineMatrix(1, 0, 0, 1, 3, 3)),
+    ]);
+
+    final VectorInstructions instructionsWithOptimizer = await parse(groupMask);
+    expect(instructionsWithOptimizer.paths, groupMaskForMaskingOptimizer);
+
+    expect(instructions.paints, const <Paint>[
+      Paint(fill: Fill(color: Color(0xff727272))),
+      Paint(fill: Fill()),
+      Paint(fill: Fill(color: Color(0xff8e93a1))),
+      Paint(fill: Fill(color: Color(0xffffffff)))
+    ]);
+
+    expect(instructions.commands, const <DrawCommand>[
+      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
+      DrawCommand(DrawCommandType.saveLayer, paintId: 1),
+      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 2),
+      DrawCommand(DrawCommandType.mask),
+      DrawCommand(DrawCommandType.path, objectId: 2, paintId: 3),
+      DrawCommand(DrawCommandType.restore),
+      DrawCommand(DrawCommandType.restore)
+    ]);
   });
 }

--- a/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
@@ -165,4 +165,65 @@ void main() {
       DrawCommand(DrawCommandType.restore)
     ]);
   });
+
+  test('Handles masks with blends and gradients correctly', () async {
+    final VectorInstructions instructions = await parse(
+      blendAndMask,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
+    expect(
+      instructions.paths,
+      <Path>[
+        PathBuilder().addOval(const Rect.fromCircle(50, 50, 50)).toPath(),
+        PathBuilder().addOval(const Rect.fromCircle(50, 50, 40)).toPath(),
+      ],
+    );
+
+    final VectorInstructions instructionsWithOptimizer =
+        await parse(blendAndMask);
+    expect(instructionsWithOptimizer.paths, blendsAndMasksForMaskingOptimizer);
+
+    const LinearGradient gradient1 = LinearGradient(
+      id: 'url(#linearGradient-3)',
+      from: Point(46.9782516, 60.9121966),
+      to: Point(60.42279469999999, 90.6839734),
+      colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
+      offsets: <double>[0.0, 1.0],
+      tileMode: TileMode.clamp,
+      unitMode: GradientUnitMode.transformed,
+    );
+    const LinearGradient gradient2 = LinearGradient(
+      id: 'url(#linearGradient-3)',
+      from: Point(47.58260128, 58.72975728),
+      to: Point(58.338235759999996, 82.54717871999999),
+      colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
+      offsets: <double>[0.0, 1.0],
+      tileMode: TileMode.clamp,
+      unitMode: GradientUnitMode.transformed,
+    );
+    expect(instructions.paints, const <Paint>[
+      Paint(fill: Fill(color: Color(0xffadd8e6))),
+      Paint(
+        blendMode: BlendMode.multiply,
+        fill: Fill(),
+      ),
+      Paint(
+        blendMode: BlendMode.multiply,
+        fill: Fill(color: Color(0x98ffffff), shader: gradient1),
+      ),
+      Paint(fill: Fill(color: Color(0x98ffffff), shader: gradient2)),
+    ]);
+
+    expect(instructions.commands, const <DrawCommand>[
+      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
+      DrawCommand(DrawCommandType.saveLayer, paintId: 1),
+      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 2),
+      DrawCommand(DrawCommandType.mask),
+      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 3),
+      DrawCommand(DrawCommandType.restore),
+      DrawCommand(DrawCommandType.restore)
+    ]);
+  });
 }

--- a/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
@@ -8,6 +8,7 @@ import 'package:vector_graphics_compiler/src/svg/overdraw_optimizer.dart';
 import 'package:vector_graphics_compiler/src/svg/parser.dart';
 import 'package:vector_graphics_compiler/src/svg/resolver.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
+import 'helpers.dart';
 import 'test_svg_strings.dart';
 
 Future<Node> parseAndResolve(String source) async {
@@ -16,25 +17,13 @@ Future<Node> parseAndResolve(String source) async {
   return node.accept(visitor, AffineMatrix.identity);
 }
 
-List<T> queryChildren<T extends Node>(Node node) {
-  final List<T> children = <T>[];
-  void visitor(Node child) {
-    if (child is T) {
-      children.add(child);
-    }
-    child.visitChildren(visitor);
-  }
-
-  node.visitChildren(visitor);
-  return children;
-}
-
 void main() {
   setUpAll(() {
     if (!initializePathOpsFromFlutterCache()) {
       fail('error in setup');
     }
   });
+
   test('Basic case of two opaque shapes overlapping', () async {
     final Node node = await parseAndResolve(basicOverlap);
     final VectorInstructions instructions = await parse(basicOverlap);

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -5,24 +5,33 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
-  setUpAll(() {
-    if (!initializePathOpsFromFlutterCache()) {
-      fail('error in setup');
-    }
-  });
-
   test('Clip with use', () async {
-    final VectorInstructions instructions = await parse(basicClip);
-    final VectorInstructions instructions2 = await parse(useClip);
+    final VectorInstructions instructions = await parse(
+      basicClip,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
+    final VectorInstructions instructions2 = await parse(
+      useClip,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions, instructions2);
   });
 
   test('stroke-dasharray="none"', () async {
-    final VectorInstructions instructions = await parse('''
+    final VectorInstructions instructions = await parse(
+      '''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <path d="M1 20L20 20L20 39L30 30L1 26z" stroke="black" fill="red" stroke-width="2" stroke-dasharray="none"/>
 </svg>
-''');
+''',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     expect(instructions.paints, const <Paint>[
       Paint(fill: Fill(color: Color(0xffff0000))),
@@ -44,10 +53,15 @@ void main() {
   });
 
   test('Dashed path', () async {
-    final VectorInstructions instructions = await parse('''
+    final VectorInstructions instructions = await parse(
+      '''
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <path d="M1 20L20 20L20 39L30 30L1 26z" stroke="black" fill="red" stroke-width="2" stroke-dasharray="5 3 5 5"/>
-</svg>''');
+</svg>''',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     expect(instructions.paints, const <Paint>[
       Paint(fill: Fill(color: Color(0xffff0000))),
@@ -103,6 +117,9 @@ void main() {
   test('text with transform', () async {
     final VectorInstructions instructions = await parse(
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160"><text transform="rotate(10 -100 50)">a</text></svg>',
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
     );
     expect(instructions.paints.single, const Paint(fill: Fill()));
     expect(
@@ -122,7 +139,12 @@ void main() {
   });
 
   test('Missing references', () async {
-    final VectorInstructions instructions = await parse(missingRefs);
+    final VectorInstructions instructions = await parse(
+      missingRefs,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paints.single,
       const Paint(fill: Fill(color: Color(0xFFFF0000))),
@@ -138,7 +160,12 @@ void main() {
   });
 
   test('focal radial', () async {
-    final VectorInstructions instructions = await parse(focalRadial);
+    final VectorInstructions instructions = await parse(
+      focalRadial,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     expect(
       instructions.paints.single,
@@ -179,7 +206,12 @@ void main() {
   });
 
   test('Transformed userSpaceOnUse radial', () async {
-    final VectorInstructions instructions = await parse(xformUsosRadial);
+    final VectorInstructions instructions = await parse(
+      xformUsosRadial,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paints.single,
       const Paint(
@@ -222,7 +254,12 @@ void main() {
 
   test('Transformed objectBoundingBox gradient onto transformed path',
       () async {
-    final VectorInstructions instructions = await parse(xformObbGradient);
+    final VectorInstructions instructions = await parse(
+      xformObbGradient,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paints.single,
       const Paint(
@@ -264,7 +301,12 @@ void main() {
   </g>
 </svg>
 ''';
-    final VectorInstructions instructions = await parse(svg);
+    final VectorInstructions instructions = await parse(
+      svg,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     expect(instructions.paints, const <Paint>[
       Paint(fill: Fill(color: Color(0xffff0000))),
@@ -282,7 +324,12 @@ void main() {
   <path fill="none" stroke="red" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.7" d="M70.822 65.557l5.376 5.296 8.389-8.676" />
 </svg>
 ''';
-    final VectorInstructions instructions = await parse(svg);
+    final VectorInstructions instructions = await parse(
+      svg,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paints.single,
       const Paint(
@@ -297,8 +344,12 @@ void main() {
   });
 
   test('gradients can handle inheriting unit mode', () async {
-    final VectorInstructions instructions =
-        await parse(linearGradientThatInheritsUnitMode);
+    final VectorInstructions instructions = await parse(
+      linearGradientThatInheritsUnitMode,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paints, const <Paint>[
       Paint(
         fill: Fill(
@@ -346,7 +397,12 @@ void main() {
   });
 
   test('group opacity results in save layer', () async {
-    final VectorInstructions instructions = await parse(groupOpacity);
+    final VectorInstructions instructions = await parse(
+      groupOpacity,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paths, <Path>[
       PathBuilder().addOval(const Rect.fromCircle(80, 100, 50)).toPath(),
       PathBuilder().addOval(const Rect.fromCircle(120, 100, 50)).toPath(),
@@ -365,8 +421,18 @@ void main() {
   });
 
   test('xlink gradient Out of order', () async {
-    final VectorInstructions instructions = await parse(xlinkGradient);
-    final VectorInstructions instructions2 = await parse(xlinkGradientOoO);
+    final VectorInstructions instructions = await parse(
+      xlinkGradient,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
+    final VectorInstructions instructions2 = await parse(
+      xlinkGradientOoO,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     expect(instructions.paints, instructions2.paints);
     expect(instructions.paths, instructions2.paths);
@@ -374,8 +440,18 @@ void main() {
   });
 
   test('xlink use Out of order', () async {
-    final VectorInstructions instructions = await parse(simpleUseCircles);
-    final VectorInstructions instructions2 = await parse(simpleUseCirclesOoO);
+    final VectorInstructions instructions = await parse(
+      simpleUseCircles,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
+    final VectorInstructions instructions2 = await parse(
+      simpleUseCirclesOoO,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
 
     // Use toSet to ignore ordering differences.
     expect(instructions.paints.toSet(), instructions2.paints.toSet());
@@ -384,7 +460,12 @@ void main() {
   });
 
   test('xlink gradient with transform', () async {
-    final VectorInstructions instructions = await parse(xlinkGradient);
+    final VectorInstructions instructions = await parse(
+      xlinkGradient,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paths, <Path>[
       PathBuilder()
           .addOval(const Rect.fromCircle(-83.533, 122.753, 74.461))
@@ -416,7 +497,12 @@ void main() {
   });
 
   test('Out of order def', () async {
-    final VectorInstructions instructions = await parse(outOfOrderGradientDef);
+    final VectorInstructions instructions = await parse(
+      outOfOrderGradientDef,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paths, <Path>[
       parseSvgPathData(
           'M10 20c5.523 0 10-4.477 10-10S15.523 0 10 0 0 4.477 0 10s4.477 10 10 10z'),
@@ -444,8 +530,12 @@ void main() {
   });
 
   test('Handles masks with blends and gradients correctly', () async {
-    final VectorInstructions instructions =
-        await parse(blendAndMask, enableMaskingOptimizer: false);
+    final VectorInstructions instructions = await parse(
+      blendAndMask,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paths,
       <Path>[
@@ -501,7 +591,12 @@ void main() {
   });
 
   test('Handles masks correctly', () async {
-    final VectorInstructions instructions = await parse(basicMask);
+    final VectorInstructions instructions = await parse(
+      basicMask,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(
       instructions.paths,
       <Path>[
@@ -532,52 +627,18 @@ void main() {
     ]);
   });
 
-  test('Masks on groups', () async {
-    final VectorInstructions instructions =
-        await parse(groupMask, enableMaskingOptimizer: false);
-    expect(instructions.paths, <Path>[
-      parseSvgPathData(
-              'M 17.438 8.438 C 17.748 8.438 18 8.69 18 9 L 18 16.313 C 17.99834725871 17.24440923535 17.24341005121 17.99889920517 16.312 18 L 1.688 18 C 0.75620021668 17.99889792932 0.00110207068 17.24379978332 0 16.312 L 0 9 C 0.01271270943 8.69855860173 0.26079065383 8.46072235233 0.5625 8.46072235233 C 0.86420934617 8.46072235233 1.11228729057 8.69855860173 1.125 9 L 1.125 16.313 C 1.125 16.622 1.377 16.875 1.688 16.875 L 16.312 16.875 C 16.622 16.875 16.875 16.622 16.875 16.312 L 16.875 9 C 16.875 8.69 17.127 8.437 17.438 8.437 Z M 9 0 C 9.169 0 9.316 0.079 9.418 0.196 L 9.423 0.192 L 13.361 4.692 C 13.443 4.795 13.5 4.921 13.5 5.062 C 13.5 5.373 13.248 5.625 12.937 5.625 C 12.77572417052 5.6238681172 12.62300981305 5.55226042805 12.519 5.429 L 12.514 5.433 L 9.563 2.06 L 9.563 11.812 C 9.56299999183 12.12293630838 9.31093630838 12.3749999852 9 12.3749999852 C 8.68906369162 12.3749999852 8.43700000817 12.12293630838 8.437 11.812 L 8.437 2.06 L 5.486 5.433 C 5.37775998399 5.5529360201 5.22453705399 5.62248401669 5.063 5.625 C 4.75206368585 5.625 4.5 5.37293631415 4.5 5.062 C 4.5 4.921 4.557 4.795 4.644 4.696 L 4.639 4.692 L 8.577 0.192 C 8.68524001601 0.0720639799 8.83846294601 0.00251598331 9 0 Z',
-              PathFillType.evenOdd)
-          .transformed(const AffineMatrix(0.00000000000000006123233995736766, 1,
-              -1, 0.00000000000000006123233995736766, 21, 3)),
-      parseSvgPathData(
-              'M -3 -3 L 21 -3 L 21 21 L -3 21 Z', PathFillType.evenOdd)
-          .transformed(const AffineMatrix(1, 0, 0, 1, 3, 3)),
-      parseSvgPathData(
-              'M 17.438 8.438 C 17.748 8.438 18 8.69 18 9 L 18 16.313 C 17.99834725871 17.24440923535 17.24341005121 17.99889920517 16.312 18 L 1.688 18 C 0.75620021668 17.99889792932 0.00110207068 17.24379978332 0 16.312 L 0 9 C 0.01271270943 8.69855860173 0.26079065383 8.46072235233 0.5625 8.46072235233 C 0.86420934617 8.46072235233 1.11228729057 8.69855860173 1.125 9 L 1.125 16.313 C 1.125 16.622 1.377 16.875 1.688 16.875 L 16.312 16.875 C 16.622 16.875 16.875 16.622 16.875 16.312 L 16.875 9 C 16.875 8.69 17.127 8.437 17.438 8.437 Z M 9 0 C 9.169 0 9.316 0.079 9.418 0.196 L 9.423 0.192 L 13.361 4.692 C 13.443 4.795 13.5 4.921 13.5 5.062 C 13.5 5.373 13.248 5.625 12.937 5.625 C 12.77572417052 5.6238681172 12.62300981305 5.55226042805 12.519 5.429 L 12.514 5.433 L 9.563 2.06 L 9.563 11.812 C 9.56299999183 12.12293630838 9.31093630838 12.3749999852 9 12.3749999852 C 8.68906369162 12.3749999852 8.43700000817 12.12293630838 8.437 11.812 L 8.437 2.06 L 5.486 5.433 C 5.37775998399 5.5529360201 5.22453705399 5.62248401669 5.063 5.625 C 4.75206368585 5.625 4.5 5.37293631415 4.5 5.062 C 4.5 4.921 4.557 4.795 4.644 4.696 L 4.639 4.692 L 8.577 0.192 C 8.68524001601 0.0720639799 8.83846294601 0.00251598331 9 0 Z',
-              PathFillType.evenOdd)
-          .transformed(const AffineMatrix(1, 0, 0, 1, 3, 3)),
-    ]);
-
-    final VectorInstructions instructionsWithOptimizer = await parse(groupMask);
-    expect(instructionsWithOptimizer.paths, groupMaskForMaskingOptimizer);
-
-    expect(instructions.paints, const <Paint>[
-      Paint(fill: Fill(color: Color(0xff727272))),
-      Paint(fill: Fill()),
-      Paint(fill: Fill(color: Color(0xff8e93a1))),
-      Paint(fill: Fill(color: Color(0xffffffff)))
-    ]);
-
-    expect(instructions.commands, const <DrawCommand>[
-      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
-      DrawCommand(DrawCommandType.saveLayer, paintId: 1),
-      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 2),
-      DrawCommand(DrawCommandType.mask),
-      DrawCommand(DrawCommandType.path, objectId: 2, paintId: 3),
-      DrawCommand(DrawCommandType.restore),
-      DrawCommand(DrawCommandType.restore)
-    ]);
-  });
-
   test('Handles viewBox transformations correctly', () async {
     const String svg = '''
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-10 -12 120 120">
   <rect x="11" y="36" width="31" height="20" fill="red" />
 </svg>
 ''';
-    final VectorInstructions instructions = await parse(svg);
+    final VectorInstructions instructions = await parse(
+      svg,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paths, <Path>[
       PathBuilder()
           .addRect(const Rect.fromLTWH(11, 36, 31, 20))
@@ -592,58 +653,16 @@ void main() {
   <rect x="11" y="36" width="31" height="20" rx="2.5" fill="red" />
 </svg>
 ''';
-    final VectorInstructions instructions = await parse(svg);
+    final VectorInstructions instructions = await parse(
+      svg,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
+    );
     expect(instructions.paths, <Path>[
       PathBuilder()
           .addRRect(const Rect.fromLTWH(11, 36, 31, 20), 2.5, 2.5)
           .toPath()
-    ]);
-  });
-
-  test('Combines clips where possible', () async {
-    final VectorInstructions instructions =
-        await parse(basicClip, enableClippingOptimizer: false);
-    final VectorInstructions instructionsWithOptimizer = await parse(basicClip);
-
-    expect(instructionsWithOptimizer.paths, basicClipsForClippingOptimzer);
-
-    expect(instructions.paths, <Path>[
-      PathBuilder()
-          .addOval(const Rect.fromCircle(30, 30, 20))
-          .addOval(const Rect.fromCircle(70, 70, 20))
-          .toPath(),
-      PathBuilder().addRect(const Rect.fromLTWH(10, 10, 100, 100)).toPath(),
-    ]);
-    expect(instructions.commands, const <DrawCommand>[
-      DrawCommand(DrawCommandType.clip, objectId: 0),
-      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 0),
-      DrawCommand(DrawCommandType.restore),
-    ]);
-  });
-
-  test('Does not combine clips with multiple fill rules', () async {
-    final VectorInstructions instructions = await parse(multiClip);
-    expect(instructions.paths, <Path>[
-      parseSvgPathData(
-          'M 250,75 L 323,301 131,161 369,161 177,301 z', PathFillType.evenOdd),
-      PathBuilder().addOval(const Rect.fromCircle(400, 200, 150)).toPath(),
-      parseSvgPathData('M 250,75 L 323,301 131,161 369,161 177,301 z')
-          .transformed(AffineMatrix.identity.translated(250, 0)),
-      PathBuilder().addOval(const Rect.fromCircle(450, 300, 150)).toPath(),
-    ]);
-    expect(instructions.commands, const <DrawCommand>[
-      DrawCommand(DrawCommandType.clip, objectId: 0),
-      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 0),
-      DrawCommand(DrawCommandType.restore),
-      DrawCommand(DrawCommandType.clip, objectId: 2),
-      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 0),
-      DrawCommand(DrawCommandType.restore),
-      DrawCommand(DrawCommandType.clip, objectId: 0),
-      DrawCommand(DrawCommandType.path, objectId: 3, paintId: 1),
-      DrawCommand(DrawCommandType.restore),
-      DrawCommand(DrawCommandType.clip, objectId: 2),
-      DrawCommand(DrawCommandType.path, objectId: 3, paintId: 1),
-      DrawCommand(DrawCommandType.restore),
     ]);
   });
 
@@ -655,6 +674,9 @@ void main() {
 </svg>''',
       key: 'emptyPath',
       warningsAsErrors: true,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
     );
     expect(instructions.commands.isEmpty, true);
   });
@@ -664,6 +686,9 @@ void main() {
       simpleUseCircles,
       key: 'useCircles',
       warningsAsErrors: true,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
     );
 
     expect(
@@ -736,6 +761,9 @@ void main() {
       ghostscriptTiger,
       key: 'ghostscriptTiger',
       warningsAsErrors: true,
+      enableClippingOptimizer: false,
+      enableMaskingOptimizer: false,
+      enableOverdrawOptimizer: false,
     );
 
     expect(instructions.paints, ghostScriptTigerPaints.toSet().toList());

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -529,67 +529,6 @@ void main() {
     ]);
   });
 
-  test('Handles masks with blends and gradients correctly', () async {
-    final VectorInstructions instructions = await parse(
-      blendAndMask,
-      enableClippingOptimizer: false,
-      enableMaskingOptimizer: false,
-      enableOverdrawOptimizer: false,
-    );
-    expect(
-      instructions.paths,
-      <Path>[
-        PathBuilder().addOval(const Rect.fromCircle(50, 50, 50)).toPath(),
-        PathBuilder().addOval(const Rect.fromCircle(50, 50, 40)).toPath(),
-      ],
-    );
-
-    final VectorInstructions instructionsWithOptimizer =
-        await parse(blendAndMask);
-    expect(instructionsWithOptimizer.paths, blendsAndMasksForMaskingOptimizer);
-
-    const LinearGradient gradient1 = LinearGradient(
-      id: 'url(#linearGradient-3)',
-      from: Point(46.9782516, 60.9121966),
-      to: Point(60.42279469999999, 90.6839734),
-      colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
-      offsets: <double>[0.0, 1.0],
-      tileMode: TileMode.clamp,
-      unitMode: GradientUnitMode.transformed,
-    );
-    const LinearGradient gradient2 = LinearGradient(
-      id: 'url(#linearGradient-3)',
-      from: Point(47.58260128, 58.72975728),
-      to: Point(58.338235759999996, 82.54717871999999),
-      colors: <Color>[Color(0xffffffff), Color(0xff0000ff)],
-      offsets: <double>[0.0, 1.0],
-      tileMode: TileMode.clamp,
-      unitMode: GradientUnitMode.transformed,
-    );
-    expect(instructions.paints, const <Paint>[
-      Paint(fill: Fill(color: Color(0xffadd8e6))),
-      Paint(
-        blendMode: BlendMode.multiply,
-        fill: Fill(),
-      ),
-      Paint(
-        blendMode: BlendMode.multiply,
-        fill: Fill(color: Color(0x98ffffff), shader: gradient1),
-      ),
-      Paint(fill: Fill(color: Color(0x98ffffff), shader: gradient2)),
-    ]);
-
-    expect(instructions.commands, const <DrawCommand>[
-      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
-      DrawCommand(DrawCommandType.saveLayer, paintId: 1),
-      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 2),
-      DrawCommand(DrawCommandType.mask),
-      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 3),
-      DrawCommand(DrawCommandType.restore),
-      DrawCommand(DrawCommandType.restore)
-    ]);
-  });
-
   test('Handles masks correctly', () async {
     final VectorInstructions instructions = await parse(
       basicMask,


### PR DESCRIPTION
We can't run tests that use native libraries in google3. To make sure that we can run as many test suites as possible, move test cases that depend on path ops into the optimizer test libraries