### PR TITLE
Handle quads

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
@@ -63,6 +63,21 @@ class Path implements PathProxy {
         case PathVerb.lineTo:
           proxy.lineTo(points[index++], points[index++]);
           break;
+        case PathVerb.quadTo:
+          // TODO(dnfield): Avoid degree elevation?
+          // The binary format only supports cubics. Skia might have
+          // used a quad when combining paths somewhere though.
+          final double cpX = points[index++];
+          final double cpY = points[index++];
+          proxy.cubicTo(
+            cpX,
+            cpY,
+            cpX,
+            cpY,
+            points[index++],
+            points[index++],
+          );
+          break;
         case PathVerb.cubicTo:
           proxy.cubicTo(
             points[index++],
@@ -91,6 +106,7 @@ class Path implements PathProxy {
   static const Map<int, PathVerb> pathVerbDict = <int, PathVerb>{
     0: PathVerb.moveTo,
     1: PathVerb.lineTo,
+    2: PathVerb.quadTo,
     4: PathVerb.cubicTo,
     5: PathVerb.close
   };

--- a/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
@@ -82,6 +82,18 @@ Path toVectorGraphicsPath(path_ops.Path path) {
       case path_ops.PathVerb.lineTo:
         newCommands.add(LineToCommand(points[index++], points[index++]));
         break;
+      case path_ops.PathVerb.quadTo:
+        final double cpX = points[index++];
+        final double cpY = points[index++];
+        newCommands.add(CubicToCommand(
+          cpX,
+          cpY,
+          cpX,
+          cpY,
+          points[index++],
+          points[index++],
+        ));
+        break;
       case path_ops.PathVerb.cubicTo:
         newCommands.add(CubicToCommand(
           points[index++],

--- a/packages/vector_graphics_compiler/lib/src/svg/path_ops.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/path_ops.dart
@@ -57,6 +57,12 @@ enum PathVerb {
   /// A straight line from the current point to the specified point.
   lineTo,
 
+  /// A quadratic bezier curve from the current point.
+  ///
+  /// The next two points are the control point. The next two points after
+  /// that are the target point.
+  quadTo,
+
   /// A cubic bezier curve from the current point.
   ///
   /// The next two points are used as the first control point. The next two

--- a/packages/vector_graphics_compiler/test/path_ops_test.dart
+++ b/packages/vector_graphics_compiler/test/path_ops_test.dart
@@ -86,4 +86,75 @@ void main() {
     quad.dispose();
     intersection.dispose();
   });
+
+  test('Quad', () {
+    final Path top = Path()
+      ..moveTo(87.998, 103.591)
+      ..lineTo(82.72, 103.591)
+      ..lineTo(82.72, 106.64999999999999)
+      ..lineTo(87.998, 106.64999999999999)
+      ..lineTo(87.998, 103.591)
+      ..close();
+
+    final Path bottom = Path()
+      ..moveTo(116.232, 154.452)
+      ..lineTo(19.031999999999996, 154.452)
+      ..cubicTo(18.671999999999997, 142.112, 21.361999999999995,
+          132.59199999999998, 26.101999999999997, 125.372)
+      ..cubicTo(32.552, 115.55199999999999, 42.782, 110.012, 54.30199999999999,
+          107.502)
+      ..cubicTo(56.931999185062395, 106.9278703703336, 59.593157782987156,
+          106.50716022812718, 62.27200212186002, 106.24200362009655)
+      ..lineTo(62.291999999999994, 106.24199999999999)
+      ..cubicTo(67.10118331429277, 105.77278829340533, 71.940772522921,
+          105.69920780785604, 76.76199850891219, 106.021997940542)
+      ..cubicTo(78.762, 106.142, 80.749, 106.32199999999999, 82.722, 106.562)
+      ..lineTo(83.362, 106.652)
+      ..cubicTo(84.112, 106.742, 84.85199999999999, 106.852, 85.592, 106.972)
+      ..cubicTo(86.852, 107.152, 88.102, 107.372, 89.342, 107.60199999999999)
+      ..cubicTo(89.542, 107.642, 89.732, 107.67199999999998, 89.922,
+          107.71199999999999)
+      ..cubicTo(91.54899999999999, 108.02599999999998, 93.14, 108.502, 94.672,
+          109.13199999999999)
+      ..cubicTo(98.35184786478965, 110.61003782601773, 101.5939983878398,
+          113.00207032444644, 104.09199525642647, 116.08199471003054)
+      ..cubicTo(104.181, 116.17999999999999, 104.264, 116.28399999999999,
+          104.342, 116.392)
+      ..cubicTo(104.512, 116.612, 104.682, 116.832, 104.842, 117.062)
+      ..cubicTo(105.102, 117.41199999999999, 105.352, 117.77199999999999,
+          105.592, 118.142)
+      ..cubicTo(107.63018430068513, 121.33505319707416, 109.25008660688327,
+          124.77650539945358, 110.41200699229772, 128.38200813032248)
+      ..cubicTo(112.762, 135.252, 114.50200000000001, 143.862, 116.232, 154.452)
+      ..close();
+
+    final Path intersect = bottom.applyOp(top, PathOp.intersect);
+    // current revision of Skia makes this result in a quad verb getting used.
+    final Path difference = bottom.applyOp(intersect, PathOp.difference);
+
+    expect(difference.verbs.toList(), <PathVerb>[
+      PathVerb.moveTo,
+      PathVerb.lineTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.quadTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.lineTo,
+      PathVerb.lineTo,
+      PathVerb.lineTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.lineTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.cubicTo,
+      PathVerb.close,
+    ]);
+  });
 }


### PR DESCRIPTION
Skia might give us a quad when we do path operations.

We can handle it by elevating them to cubics.