### PR TITLE
Fix fill type for applyOp

### DIFF
--- a/packages/vector_graphics/example/pubspec.yaml
+++ b/packages/vector_graphics/example/pubspec.yaml
@@ -21,9 +21,6 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-  assets:
-    - assets/tiger.bin # ghostscript tiger
-
 
 # Comment out before publishing
 dependency_overrides:

--- a/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
@@ -38,7 +38,6 @@ class Path implements PathProxy {
     return FillType.values[_getFillTypeFn(_path!)];
   }
 
-
   ffi.Pointer<_SkPath>? _path;
   ffi.Pointer<_PathData>? _pathData;
 

--- a/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_path_ops_ffi.dart
@@ -22,7 +22,7 @@ late final String _dylibPath;
 /// [dispose] has been called, this class must not be used again.
 class Path implements PathProxy {
   /// Creates an empty path object with the specified fill type.
-  Path([this.fillType = FillType.nonZero])
+  Path([FillType fillType = FillType.nonZero])
       : _path = _createPathFn(fillType.index);
 
   /// Creates a copy of this path.
@@ -33,7 +33,11 @@ class Path implements PathProxy {
   }
 
   /// The [FillType] of this path.
-  final FillType fillType;
+  FillType get fillType {
+    assert(_path != null);
+    return FillType.values[_getFillTypeFn(_path!)];
+  }
+
 
   ffi.Pointer<_SkPath>? _path;
   ffi.Pointer<_PathData>? _pathData;
@@ -295,3 +299,9 @@ typedef _destroy_data_type = ffi.Void Function(ffi.Pointer<_PathData>);
 
 final _DestroyDataType _destroyDataFn =
     _dylib.lookupFunction<_destroy_data_type, _DestroyDataType>('DestroyData');
+
+typedef _GetFillTypeType = int Function(ffi.Pointer<_SkPath>);
+typedef _get_fill_type_type = ffi.Int32 Function(ffi.Pointer<_SkPath>);
+
+final _GetFillTypeType _getFillTypeFn =
+    _dylib.lookupFunction<_get_fill_type_type, _GetFillTypeType>('GetFillType');

--- a/packages/vector_graphics_compiler/test/clipping_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/clipping_optimizer_test.dart
@@ -161,4 +161,24 @@ void main() {
       DrawCommand(DrawCommandType.restore),
     ]);
   });
+
+  test('Preserves fill type changes', () async {
+    const String svg = '''
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#a)">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M9.99 0C4.47 0 0 4.48 0 10s4.47 10 9.99 10C15.52 20 20 15.52 20 10S15.52 0 9.99 0zM11 11V5H9v6h2zm0 4v-2H9v2h2zm-9-5c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8-8 3.58-8 8z" fill="black" />
+    </g>
+    <defs>
+        <clipPath id="a">
+            <path fill="#fff" d="M0 0h20v20H0z" />
+        </clipPath>
+    </defs>
+</svg>''';
+    final VectorInstructions instructions = await parse(svg);
+
+    expect(
+      instructions.paths.single.fillType,
+      PathFillType.evenOdd,
+    );
+  });
 }

--- a/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
@@ -92,6 +92,7 @@ void main() {
 
     expect(instructions.paths, <Path>[
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(367.0, 221.5),
           LineToCommand(99.0, 221.5),
@@ -139,6 +140,7 @@ void main() {
 
     expect(instructions.paths, <Path>[
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(343.0, 240.5),
           LineToCommand(88.0, 240.5),
@@ -155,6 +157,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(484.0, 63.5),
           LineToCommand(343.0, 63.5),
@@ -171,6 +174,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(343.0, 240.5),
           LineToCommand(484.0, 240.5),
@@ -201,6 +205,7 @@ void main() {
 
     expect(instructions.paths, <Path>[
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(343.0, 240.5),
           LineToCommand(88.0, 240.5),
@@ -248,6 +253,7 @@ void main() {
 
     expect(instructions.paths, <Path>[
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(343.0, 240.5),
           LineToCommand(88.0, 240.5),
@@ -264,6 +270,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(484.0, 63.5),
           LineToCommand(343.0, 63.5),
@@ -280,6 +287,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(343.0, 240.5),
           LineToCommand(484.0, 240.5),
@@ -337,6 +345,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(150.0, 100.0),
           LineToCommand(100.0, 100.0),
@@ -352,6 +361,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(200.0, 50.0),
           CubicToCommand(
@@ -366,6 +376,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(400.0, 50.0),
           CubicToCommand(
@@ -379,8 +390,11 @@ void main() {
           CloseCommand()
         ],
       ),
-      Path(),
       Path(
+        fillType: PathFillType.evenOdd,
+      ),
+      Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(600.0, 50.0),
           CubicToCommand(
@@ -395,6 +409,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(800.0, 50.0),
           CubicToCommand(
@@ -409,6 +424,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(1000.0, 50.0),
           CubicToCommand(
@@ -423,6 +439,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(200.0000457763672, 203.1529998779297),
           CubicToCommand(194.55233764648438, 201.1146697998047,
@@ -441,6 +458,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(217.5, 200.0),
           CubicToCommand(
@@ -455,6 +473,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(382.5, 200.0),
           CubicToCommand(410.09576416015625, 200.0, 432.5, 222.4042510986328,
@@ -469,6 +488,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(417.5, 200.0),
           CubicToCommand(445.09576416015625, 200.0, 467.5, 222.4042510986328,
@@ -483,6 +503,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(582.5, 200.0),
           CubicToCommand(
@@ -497,6 +518,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(617.5, 200.0),
           CubicToCommand(
@@ -511,6 +533,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(817.5, 200.0),
           CubicToCommand(
@@ -525,6 +548,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(782.5, 200.0),
           CubicToCommand(
@@ -539,6 +563,7 @@ void main() {
         ],
       ),
       Path(
+        fillType: PathFillType.evenOdd,
         commands: const <PathCommand>[
           MoveToCommand(982.5, 200.0),
           CubicToCommand(1010.0957641601562, 200.0, 1032.5, 222.4042510986328,

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -1220,51 +1220,59 @@ List<Path> groupMaskForMaskingOptimizer = <Path>[
 
 /// Excpected groupMask result when [MaskingOptimizer] is applied
 List<Path> blendsAndMasksForMaskingOptimizer = <Path>[
-  Path(commands: const <PathCommand>[
-    MoveToCommand(50.0, 0.0),
-    CubicToCommand(77.5957512247, 0.0, 100.0, 22.4042487753, 100.0, 50.0),
-    CubicToCommand(100.0, 77.5957512247, 77.5957512247, 100.0, 50.0, 100.0),
-    CubicToCommand(22.4042487753, 100.0, 0.0, 77.5957512247, 0.0, 50.0),
-    CubicToCommand(0.0, 22.4042487753, 22.4042487753, 0.0, 50.0, 0.0),
-    CloseCommand()
-  ]),
-  Path(commands: const <PathCommand>[
-    MoveToCommand(90.0, 50.0),
-    CubicToCommand(
-        90.0, 27.923398971557617, 72.07659912109375, 10.0, 50.0, 10.0),
-    CubicToCommand(
-        27.923398971557617, 10.0, 10.0, 27.923398971557617, 10.0, 50.0),
-    CubicToCommand(
-        10.0, 72.07659912109375, 27.923398971557617, 90.0, 50.0, 90.0),
-    CubicToCommand(
-        72.07659912109375, 90.0, 90.0, 72.07659912109375, 90.0, 50.0),
-    CloseCommand()
-  ]),
+  Path(
+    commands: const <PathCommand>[
+      MoveToCommand(50.0, 0.0),
+      CubicToCommand(77.5957512247, 0.0, 100.0, 22.4042487753, 100.0, 50.0),
+      CubicToCommand(100.0, 77.5957512247, 77.5957512247, 100.0, 50.0, 100.0),
+      CubicToCommand(22.4042487753, 100.0, 0.0, 77.5957512247, 0.0, 50.0),
+      CubicToCommand(0.0, 22.4042487753, 22.4042487753, 0.0, 50.0, 0.0),
+      CloseCommand(),
+    ],
+  ),
+  Path(
+    fillType: PathFillType.evenOdd,
+    commands: const <PathCommand>[
+      MoveToCommand(90.0, 50.0),
+      CubicToCommand(
+          90.0, 27.923398971557617, 72.07659912109375, 10.0, 50.0, 10.0),
+      CubicToCommand(
+          27.923398971557617, 10.0, 10.0, 27.923398971557617, 10.0, 50.0),
+      CubicToCommand(
+          10.0, 72.07659912109375, 27.923398971557617, 90.0, 50.0, 90.0),
+      CubicToCommand(
+          72.07659912109375, 90.0, 90.0, 72.07659912109375, 90.0, 50.0),
+      CloseCommand(),
+    ],
+  ),
 ];
 
 /// Expected basicClips result when [Clipping Optimizer] is applied
 
 List<Path> basicClipsForClippingOptimzer = <Path>[
-  Path(commands: const <PathCommand>[
-    MoveToCommand(50.0, 30.0),
-    CubicToCommand(
-        50.0, 18.961700439453125, 41.038299560546875, 10.0, 30.0, 10.0),
-    CubicToCommand(
-        18.961700439453125, 10.0, 10.0, 18.961700439453125, 10.0, 30.0),
-    CubicToCommand(
-        10.0, 41.038299560546875, 18.961700439453125, 50.0, 30.0, 50.0),
-    CubicToCommand(
-        41.038299560546875, 50.0, 50.0, 41.038299560546875, 50.0, 30.0),
-    CloseCommand(),
-    MoveToCommand(90.0, 70.0),
-    CubicToCommand(
-        90.0, 58.961700439453125, 81.03829956054688, 50.0, 70.0, 50.0),
-    CubicToCommand(
-        58.961700439453125, 50.0, 50.0, 58.961700439453125, 50.0, 70.0),
-    CubicToCommand(
-        50.0, 81.03829956054688, 58.961700439453125, 90.0, 70.0, 90.0),
-    CubicToCommand(
-        81.03829956054688, 90.0, 90.0, 81.03829956054688, 90.0, 70.0),
-    CloseCommand()
-  ]),
+  Path(
+    fillType: PathFillType.evenOdd,
+    commands: const <PathCommand>[
+      MoveToCommand(50.0, 30.0),
+      CubicToCommand(
+          50.0, 18.961700439453125, 41.038299560546875, 10.0, 30.0, 10.0),
+      CubicToCommand(
+          18.961700439453125, 10.0, 10.0, 18.961700439453125, 10.0, 30.0),
+      CubicToCommand(
+          10.0, 41.038299560546875, 18.961700439453125, 50.0, 30.0, 50.0),
+      CubicToCommand(
+          41.038299560546875, 50.0, 50.0, 41.038299560546875, 50.0, 30.0),
+      CloseCommand(),
+      MoveToCommand(90.0, 70.0),
+      CubicToCommand(
+          90.0, 58.961700439453125, 81.03829956054688, 50.0, 70.0, 50.0),
+      CubicToCommand(
+          58.961700439453125, 50.0, 50.0, 58.961700439453125, 50.0, 70.0),
+      CubicToCommand(
+          50.0, 81.03829956054688, 58.961700439453125, 90.0, 70.0, 90.0),
+      CubicToCommand(
+          81.03829956054688, 90.0, 90.0, 81.03829956054688, 90.0, 70.0),
+      CloseCommand()
+    ],
+  ),
 ];


### PR DESCRIPTION
Fixes https://github.com/dnfield/vector_graphics/issues/133

This change made me realize that there's no pubspec dependency on Flutter in the compiler, but we indirectly depend on Flutter because of path_ops/libtessellator. I'm not sure what to do about that.