### PR TITLE
add a hidden debugging format

### DIFF
--- a/packages/vector_graphics_compiler/bin/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/bin/vector_graphics_compiler.dart
@@ -55,7 +55,7 @@ final ArgParser argParser = ArgParser()
       abbr: 'k',
       help: 'The maximum number of SVG processing isolates to spawn at once. '
           'If not provided, defaults to the number of cores.')
-  ..addOption('dump-debug',
+  ..addFlag('dump-debug',
       help:
           'Dump a human readable debugging format alongside the compiled asset',
       hide: true)

--- a/packages/vector_graphics_compiler/bin/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/bin/vector_graphics_compiler.dart
@@ -55,6 +55,10 @@ final ArgParser argParser = ArgParser()
       abbr: 'k',
       help: 'The maximum number of SVG processing isolates to spawn at once. '
           'If not provided, defaults to the number of cores.')
+  ..addOption('dump-debug',
+      help:
+          'Dump a human readable debugging format alongside the compiled asset',
+      hide: true)
   ..addOption(
     'output',
     abbr: 'o',
@@ -113,6 +117,7 @@ Future<void> main(List<String> args) async {
   final bool clippingOptimizerEnabled = results['optimize-clips'] == true;
   final bool overdrawOptimizerEnabled = results['optimize-overdraw'] == true;
   final bool tessellate = results['tessellate'] == true;
+  final bool dumpDebug = results['dump-debug'] == true;
   final int concurrency;
   if (results.wasParsed('concurrency')) {
     concurrency = int.parse(results['concurrency'] as String);
@@ -131,6 +136,7 @@ Future<void> main(List<String> args) async {
     clippingOptimizerEnabled: clippingOptimizerEnabled,
     overdrawOptimizerEnabled: overdrawOptimizerEnabled,
     tessellate: tessellate,
+    dumpDebug: dumpDebug,
   )) {
     exit(1);
   }

--- a/packages/vector_graphics_compiler/lib/src/debug_format.dart
+++ b/packages/vector_graphics_compiler/lib/src/debug_format.dart
@@ -1,0 +1,180 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:vector_graphics_codec/vector_graphics_codec.dart';
+
+/// Write an unstable but human readable form of the vector graphics binary
+/// package intended to be used for debugging and development.
+Uint8List dumpToDebugFormat(Uint8List bytes) {
+  const VectorGraphicsCodec codec = VectorGraphicsCodec();
+  final _DebugVectorGraphicsListener listener = _DebugVectorGraphicsListener();
+  final DecodeResponse response =
+      codec.decode(bytes.buffer.asByteData(), listener);
+  if (!response.complete) {
+    codec.decode(bytes.buffer.asByteData(), listener, response: response);
+  }
+  return utf8.encode(listener.buffer.toString()) as Uint8List;
+}
+
+class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
+  final StringBuffer buffer = StringBuffer();
+
+  @override
+  void onClipPath(int pathId) {
+    buffer.writeln('ApplyClip: $pathId');
+  }
+
+  @override
+  void onDrawImage(int imageId, double x, double y, double width, double height,
+      Float64List? transform) {
+    buffer.writeln(
+        'DrawImage: $imageId (Rect.fromLTWH($x, $y, $width, $height), transform: $transform)');
+  }
+
+  @override
+  void onDrawPath(int pathId, int? paintId, int? patternId) {
+    buffer.writeln('DrawPath: $pathId ($paintId, $patternId)');
+  }
+
+  @override
+  void onDrawText(int textId, int paintId, int? patternId) {
+    buffer.writeln('DrawText: $textId ($paintId, $patternId)');
+  }
+
+  @override
+  void onDrawVertices(Float32List vertices, Uint16List? indices, int? paintId) {
+    buffer.writeln(
+        'DrawVertices: ${vertices.lengthInBytes} (${indices?.lengthInBytes ?? 0}, $paintId)');
+  }
+
+  @override
+  void onImage(int imageId, int format, Uint8List data) {
+    buffer.writeln('StoreImage: $imageId ($format, ${data.lengthInBytes}');
+  }
+
+  @override
+  void onLinearGradient(double fromX, double fromY, double toX, double toY,
+      Int32List colors, Float32List? offsets, int tileMode, int id) {
+    buffer.writeln(
+        'StoreGradient: $id Linear(from: ($fromX, $fromY), to: ($toX, $toY), '
+        'colors: $colors, offsets: $offsets, tileMode: $tileMode');
+  }
+
+  @override
+  void onMask() {
+    buffer.writeln('BeginMask:');
+  }
+
+  @override
+  void onPaintObject({
+    required int color,
+    required int? strokeCap,
+    required int? strokeJoin,
+    required int blendMode,
+    required double? strokeMiterLimit,
+    required double? strokeWidth,
+    required int paintStyle,
+    required int id,
+    required int? shaderId,
+  }) {
+    // Fill
+    if (paintStyle == 0) {
+      buffer.writeln(
+          'StorePaint: $id Fill($color, blendMode: $blendMode, shader: $shaderId');
+    } else {
+      buffer.writeln(
+          'StorePaint: $id Stroke($color, strokeCap: $strokeCap, $strokeJoin: $strokeJoin, '
+          'blendMode: $blendMode, strokeMiterLimit: $strokeMiterLimit, strokeWidth: $strokeWidth, shader: $shaderId');
+    }
+  }
+
+  @override
+  void onPathClose() {
+    buffer.writeln('  close()');
+  }
+
+  @override
+  void onPathCubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3) {
+    buffer.writeln('  cubicTo(($x1, $y1), ($x2, $y2), ($x3, $y3)');
+  }
+
+  @override
+  void onPathFinished() {
+    buffer.writeln('EndPath:');
+  }
+
+  @override
+  void onPathLineTo(double x, double y) {
+    buffer.writeln('  lineTo($x, $y)');
+  }
+
+  @override
+  void onPathMoveTo(double x, double y) {
+    buffer.writeln('  moveTo($x, $y)');
+  }
+
+  @override
+  void onPathStart(int id, int fillType) {
+    buffer.writeln('PathStart: $id ${fillType == 0 ? 'Fill' : 'Stroke'}');
+  }
+
+  @override
+  void onPatternStart(int patternId, double x, double y, double width,
+      double height, Float64List transform) {
+    buffer.writeln(
+        'StorePattern: $patternId (Rect.fromLTWH($x, $y, $width, $height), transform: $transform)');
+  }
+
+  @override
+  void onRadialGradient(
+      double centerX,
+      double centerY,
+      double radius,
+      double? focalX,
+      double? focalY,
+      Int32List colors,
+      Float32List? offsets,
+      Float64List? transform,
+      int tileMode,
+      int id) {
+    buffer.writeln(
+        'StoreGradient: $id Radial(center: ($centerX, $centerY), radius: $radius,'
+        ' focal: ($focalX, $focalY), colors: $colors, offsets: $offsets, '
+        'transform: $transform, tileMode: $tileMode');
+  }
+
+  @override
+  void onRestoreLayer() {
+    buffer.writeln('Restore:');
+  }
+
+  @override
+  void onSaveLayer(int paintId) {
+    buffer.writeln('SaveLayer: $paintId');
+  }
+
+  @override
+  void onSize(double width, double height) {
+    buffer.writeln('RecordSize: Size($width, $height)');
+  }
+
+  @override
+  void onTextConfig(
+    String text,
+    String? fontFamily,
+    double x,
+    double y,
+    int fontWeight,
+    double fontSize,
+    Float64List? transform,
+    int id,
+  ) {
+    buffer.writeln(
+        'RecordText: $id ($text, ($x, $y), weight: $fontWeight, size: $fontSize, family: $fontFamily, transform: $transform)');
+  }
+}

--- a/packages/vector_graphics_compiler/lib/src/debug_format.dart
+++ b/packages/vector_graphics_compiler/lib/src/debug_format.dart
@@ -7,6 +7,8 @@ import 'dart:typed_data';
 
 import 'package:vector_graphics_codec/vector_graphics_codec.dart';
 
+import 'paint.dart';
+
 /// Write an unstable but human readable form of the vector graphics binary
 /// package intended to be used for debugging and development.
 Uint8List dumpToDebugFormat(Uint8List bytes) {
@@ -41,7 +43,9 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
 
   @override
   void onDrawPath(int pathId, int? paintId, int? patternId) {
-    buffer.writeln('DrawPath: id:$pathId ($paintId, $patternId)');
+    final String patternContext =
+        patternId != null ? ', patternId:$patternId' : '';
+    buffer.writeln('DrawPath: id:$pathId (paintId:$paintId$patternContext)');
   }
 
   @override
@@ -64,8 +68,13 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
   void onLinearGradient(double fromX, double fromY, double toX, double toY,
       Int32List colors, Float32List? offsets, int tileMode, int id) {
     buffer.writeln(
-        'StoreGradient: id:$id Linear(from: ($fromX, $fromY), to: ($toX, $toY), '
-        'colors: [${colors.map(_intToColor).join(',')}], offsets: $offsets, tileMode: $tileMode');
+      'StoreGradient: id:$id Linear(\n'
+      '  from: ($fromX, $fromY)\n'
+      '  to: ($toX, $toY)\n'
+      '  colors: [${colors.map(_intToColor).join(',')}]\n'
+      '  offsets: $offsets\n'
+      '  tileMode: ${TileMode.values[tileMode].name}',
+    );
   }
 
   @override
@@ -88,11 +97,11 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
     // Fill
     if (paintStyle == 0) {
       buffer.writeln(
-          'StorePaint: id:$id Fill(${_intToColor(color)}, blendMode: $blendMode, shader: $shaderId');
+          'StorePaint: id:$id Fill(${_intToColor(color)}, blendMode: ${BlendMode.values[blendMode].name}, shader: $shaderId)');
     } else {
       buffer.writeln(
           'StorePaint: id:$id Stroke(${_intToColor(color)}, strokeCap: $strokeCap, $strokeJoin: $strokeJoin, '
-          'blendMode: $blendMode, strokeMiterLimit: $strokeMiterLimit, strokeWidth: $strokeWidth, shader: $shaderId');
+          'blendMode: ${BlendMode.values[blendMode].name}, strokeMiterLimit: $strokeMiterLimit, strokeWidth: $strokeWidth, shader: $shaderId)');
     }
   }
 
@@ -124,7 +133,8 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
 
   @override
   void onPathStart(int id, int fillType) {
-    buffer.writeln('PathStart: id:$id ${fillType == 0 ? 'Fill' : 'Stroke'}');
+    buffer
+        .writeln('PathStart: id:$id ${fillType == 0 ? 'nonZero' : 'evenOdd'}');
   }
 
   @override
@@ -146,10 +156,17 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
       Float64List? transform,
       int tileMode,
       int id) {
+    final bool hasFocal = focalX != null;
     buffer.writeln(
-        'StoreGradient: id:$id Radial(center: ($centerX, $centerY), radius: $radius,'
-        ' focal: ($focalX, $focalY), colors: [${colors.map(_intToColor).join(',')}], offsets: $offsets, '
-        'transform: $transform, tileMode: $tileMode');
+      'StoreGradient: id:$id Radial(\n'
+      'center: ($centerX, $centerY)\n'
+      'radius: $radius\n'
+      '${hasFocal ? 'focal: ($focalX, $focalY)\n' : ''}'
+      'colors: [${colors.map(_intToColor).join(',')}]\n'
+      'offsets: $offsets\n'
+      'transform: $transform\n'
+      'tileMode: ${TileMode.values[tileMode].name}',
+    );
   }
 
   @override

--- a/packages/vector_graphics_compiler/lib/src/debug_format.dart
+++ b/packages/vector_graphics_compiler/lib/src/debug_format.dart
@@ -20,48 +20,52 @@ Uint8List dumpToDebugFormat(Uint8List bytes) {
   return utf8.encode(listener.buffer.toString()) as Uint8List;
 }
 
+String _intToColor(int value) {
+  return 'Color(0x${(value & 0xFFFFFFFF).toRadixString(16).padLeft(8, '0')})';
+}
+
 class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
   final StringBuffer buffer = StringBuffer();
 
   @override
   void onClipPath(int pathId) {
-    buffer.writeln('ApplyClip: $pathId');
+    buffer.writeln('DrawClip: id:$pathId');
   }
 
   @override
   void onDrawImage(int imageId, double x, double y, double width, double height,
       Float64List? transform) {
     buffer.writeln(
-        'DrawImage: $imageId (Rect.fromLTWH($x, $y, $width, $height), transform: $transform)');
+        'DrawImage: id:$imageId (Rect.fromLTWH($x, $y, $width, $height), transform: $transform)');
   }
 
   @override
   void onDrawPath(int pathId, int? paintId, int? patternId) {
-    buffer.writeln('DrawPath: $pathId ($paintId, $patternId)');
+    buffer.writeln('DrawPath: id:$pathId ($paintId, $patternId)');
   }
 
   @override
   void onDrawText(int textId, int paintId, int? patternId) {
-    buffer.writeln('DrawText: $textId ($paintId, $patternId)');
+    buffer.writeln('DrawText: id:$textId ($paintId, $patternId)');
   }
 
   @override
   void onDrawVertices(Float32List vertices, Uint16List? indices, int? paintId) {
-    buffer.writeln(
-        'DrawVertices: ${vertices.lengthInBytes} (${indices?.lengthInBytes ?? 0}, $paintId)');
+    buffer.writeln('DrawVertices: $vertices ($indices, paintId: $paintId)');
   }
 
   @override
   void onImage(int imageId, int format, Uint8List data) {
-    buffer.writeln('StoreImage: $imageId ($format, ${data.lengthInBytes}');
+    buffer.writeln(
+        'StoreImage: id:$imageId (format:$format, byteLength:${data.lengthInBytes}');
   }
 
   @override
   void onLinearGradient(double fromX, double fromY, double toX, double toY,
       Int32List colors, Float32List? offsets, int tileMode, int id) {
     buffer.writeln(
-        'StoreGradient: $id Linear(from: ($fromX, $fromY), to: ($toX, $toY), '
-        'colors: $colors, offsets: $offsets, tileMode: $tileMode');
+        'StoreGradient: id:$id Linear(from: ($fromX, $fromY), to: ($toX, $toY), '
+        'colors: [${colors.map(_intToColor).join(',')}], offsets: $offsets, tileMode: $tileMode');
   }
 
   @override
@@ -84,10 +88,10 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
     // Fill
     if (paintStyle == 0) {
       buffer.writeln(
-          'StorePaint: $id Fill($color, blendMode: $blendMode, shader: $shaderId');
+          'StorePaint: id:$id Fill(${_intToColor(color)}, blendMode: $blendMode, shader: $shaderId');
     } else {
       buffer.writeln(
-          'StorePaint: $id Stroke($color, strokeCap: $strokeCap, $strokeJoin: $strokeJoin, '
+          'StorePaint: id:$id Stroke(${_intToColor(color)}, strokeCap: $strokeCap, $strokeJoin: $strokeJoin, '
           'blendMode: $blendMode, strokeMiterLimit: $strokeMiterLimit, strokeWidth: $strokeWidth, shader: $shaderId');
     }
   }
@@ -120,7 +124,7 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
 
   @override
   void onPathStart(int id, int fillType) {
-    buffer.writeln('PathStart: $id ${fillType == 0 ? 'Fill' : 'Stroke'}');
+    buffer.writeln('PathStart: id:$id ${fillType == 0 ? 'Fill' : 'Stroke'}');
   }
 
   @override
@@ -143,8 +147,8 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
       int tileMode,
       int id) {
     buffer.writeln(
-        'StoreGradient: $id Radial(center: ($centerX, $centerY), radius: $radius,'
-        ' focal: ($focalX, $focalY), colors: $colors, offsets: $offsets, '
+        'StoreGradient: id:$id Radial(center: ($centerX, $centerY), radius: $radius,'
+        ' focal: ($focalX, $focalY), colors: [${colors.map(_intToColor).join(',')}], offsets: $offsets, '
         'transform: $transform, tileMode: $tileMode');
   }
 
@@ -175,6 +179,6 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
     int id,
   ) {
     buffer.writeln(
-        'RecordText: $id ($text, ($x, $y), weight: $fontWeight, size: $fontSize, family: $fontFamily, transform: $transform)');
+        'RecordText: id:$id ($text, ($x, $y), weight: $fontWeight, size: $fontSize, family: $fontFamily, transform: $transform)');
   }
 }

--- a/packages/vector_graphics_compiler/lib/src/isolate_processor.dart
+++ b/packages/vector_graphics_compiler/lib/src/isolate_processor.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'package:pool/pool.dart';
 
 import '../vector_graphics_compiler.dart';
+import 'debug_format.dart';
 
 /// The isolate processor distributes SVG compilation across multiple isolates.
 class IsolateProcessor {
@@ -32,6 +33,7 @@ class IsolateProcessor {
     required bool clippingOptimizerEnabled,
     required bool overdrawOptimizerEnabled,
     required bool tessellate,
+    required bool dumpDebug,
   }) async {
     _total = pairs.length;
     _current = 0;
@@ -44,6 +46,7 @@ class IsolateProcessor {
           clippingOptimizerEnabled: clippingOptimizerEnabled,
           overdrawOptimizerEnabled: overdrawOptimizerEnabled,
           tessellate: tessellate,
+          dumpDebug: dumpDebug,
           libpathops: _libpathops,
           libtessellator: _libtessellator,
         ).catchError((dynamic error, [StackTrace? stackTrace]) {
@@ -81,6 +84,7 @@ class IsolateProcessor {
     required bool clippingOptimizerEnabled,
     required bool overdrawOptimizerEnabled,
     required bool tessellate,
+    required bool dumpDebug,
     required String? libpathops,
     required String? libtessellator,
   }) async {
@@ -105,6 +109,10 @@ class IsolateProcessor {
           enableOverdrawOptimizer: overdrawOptimizerEnabled,
         );
         File(pair.outputPath).writeAsBytesSync(bytes);
+        if (dumpDebug) {
+          final Uint8List debugBytes = dumpToDebugFormat(bytes);
+          File(pair.outputPath + '.debug').writeAsBytesSync(debugBytes);
+        }
       });
       _current++;
       print('Progress: $_current/$_total');

--- a/packages/vector_graphics_compiler/test/cli_test.dart
+++ b/packages/vector_graphics_compiler/test/cli_test.dart
@@ -20,12 +20,41 @@ void main() {
         clippingOptimizerEnabled: false,
         overdrawOptimizerEnabled: false,
         tessellate: false,
+        dumpDebug: false,
       );
       expect(result, isTrue);
       expect(output.existsSync(), isTrue);
     } finally {
       if (output.existsSync()) {
         output.deleteSync();
+      }
+    }
+  });
+
+  test('Can dump debug format with isolate processor', () async {
+    final File output = File('test_data/example.vec');
+    final File outputDebug = File('test_data/example.vec.debug');
+    try {
+      final IsolateProcessor processor = IsolateProcessor(null, null, 4);
+      final bool result = await processor.process(
+        <Pair>[
+          Pair('test_data/example.svg', output.path),
+        ],
+        maskingOptimizerEnabled: false,
+        clippingOptimizerEnabled: false,
+        overdrawOptimizerEnabled: false,
+        tessellate: false,
+        dumpDebug: true,
+      );
+      expect(result, isTrue);
+      expect(output.existsSync(), isTrue);
+      expect(outputDebug.existsSync(), isTrue);
+    } finally {
+      if (output.existsSync()) {
+        output.deleteSync();
+      }
+      if (outputDebug.existsSync()) {
+        outputDebug.deleteSync();
       }
     }
   });


### PR DESCRIPTION
Example:

```
RecordSize: Size(166.0, 202.0)
StoreGradient: id:0 Linear(from: (79.52133178710938, 170.67616271972656), to: (83.4103775024414, 174.56521606445312), colors: [Color(0x26000000),Color(0x02616161)], offsets: [0.20000000298023224, 0.8500000238418579], tileMode: 0
StoreGradient: id:1 Linear(from: (79.5, 142.8000030517578), to: (120.9000015258789, 142.8000030517578), colors: [Color(0x8c000000),Color(0x02616161)], offsets: [0.20000000298023224, 0.8500000238418579], tileMode: 0
StorePaint: id:0 Fill(Color(0xcc42a5f5), blendMode: 3, shader: null
StorePaint: id:1 Fill(Color(0xf542a5f5), blendMode: 3, shader: null
StorePaint: id:2 Fill(Color(0xff0d47a1), blendMode: 3, shader: null
StorePaint: id:3 Fill(Color(0xff42a5f5), blendMode: 3, shader: null
StorePaint: id:4 Fill(Color(0xffffffff), blendMode: 3, shader: 0
StorePaint: id:5 Fill(Color(0xffffffff), blendMode: 3, shader: 1
PathStart: id:0 Stroke
  moveTo(37.70000076293945, 128.89999389648438)
  lineTo(9.800000190734863, 101.0)
  lineTo(100.4000015258789, 10.399999618530273)
  lineTo(156.1999969482422, 10.399999618530273)
EndPath:
PathStart: id:1 Stroke
  moveTo(156.1999969482422, 94.0)
  lineTo(100.4000015258789, 94.0)
  lineTo(79.5, 114.9000015258789)
  lineTo(107.4000015258789, 142.8000030517578)
EndPath:
PathStart: id:2 Stroke
EndPath:
PathStart: id:3 Fill
  moveTo(79.5, 170.6999969482422)
  lineTo(100.4000015258789, 191.60000610351562)
  lineTo(156.1999969482422, 191.60000610351562)
  lineTo(156.1999969482422, 191.60000610351562)
  lineTo(107.4000015258789, 142.8000030517578)
EndPath:
PathStart: id:4 Fill
  moveTo(51.661590576171875, 142.81643676757812)
  lineTo(79.52133178710938, 114.9566879272461)
  lineTo(107.38107299804688, 142.81643676757812)
  lineTo(79.52133178710938, 170.67616271972656)
  close()
EndPath:
PathStart: id:5 Fill
  moveTo(79.52133178710938, 170.67616271972656)
  lineTo(107.38107299804688, 142.81643676757812)
  lineTo(111.2701187133789, 146.70547485351562)
  lineTo(83.4103775024414, 174.56521606445312)
  close()
EndPath:
PathStart: id:6 Fill
  moveTo(79.5, 170.6999969482422)
  lineTo(120.9000015258789, 156.39999389648438)
  lineTo(107.4000015258789, 142.8000030517578)
EndPath:
DrawPath: id:0 (0, null)
DrawPath: id:1 (0, null)
DrawPath: id:2 (1, null)
DrawPath: id:3 (2, null)
DrawPath: id:4 (3, null)
DrawPath: id:5 (4, null)
DrawPath: id:6 (5, null)

```

Useful for understanding how vector graphics will process a given SVG