### PR TITLE
Avoid emitting empty paths

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
+++ b/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
@@ -73,6 +73,9 @@ class DrawCommandBuilder {
 
   /// Add a path to the current draw command stack
   void addPath(Path path, Paint paint, String? debugString, int? patternId) {
+    if (path.isEmpty) {
+      return;
+    }
     final int pathId = _getOrGenerateId(path, _paths);
     final int paintId = _getOrGenerateId(paint, _paints);
 

--- a/packages/vector_graphics_compiler/test/draw_command_builder_test.dart
+++ b/packages/vector_graphics_compiler/test/draw_command_builder_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:vector_graphics_compiler/src/draw_command_builder.dart';
+import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
+
+void main() {
+  test('DrawCommandBuilder does not emit empty paths', () {
+    final DrawCommandBuilder builder = DrawCommandBuilder();
+    builder.addPath(Path(), const Paint(), null, null);
+    expect(builder.toInstructions(100, 100).commands, isEmpty);
+  });
+}

--- a/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
@@ -320,17 +320,13 @@ void main() {
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xccff0000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x99ff0000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x66ff0000))),
-      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xc2ff0000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x33ff0000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xff008000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xbfff0000))),
-      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xffbf2000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xbf008000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x7fff0000))),
-      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xdf913700))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x7f008000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x3fff0000))),
-      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x9fff0000))),
       Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0x3f008000)))
     ]);
 
@@ -389,9 +385,6 @@ void main() {
               350.0, 72.40425109863281, 372.40423583984375, 50.0, 400.0, 50.0),
           CloseCommand()
         ],
-      ),
-      Path(
-        fillType: PathFillType.evenOdd,
       ),
       Path(
         fillType: PathFillType.evenOdd,


### PR DESCRIPTION
Optimizers can sometimes result in empty paths. It's a bit difficult to catch this - one possibility woul dbe to say that no `ResolvedPathNode` should ever have an empty path, but that means such a node can't even be used temporarily. Maybe we should do that and use null in those cases.

Anyway this puts a stop to emitting them into the final buffer.