### PR TITLE
Apply transforms to more nodes, fix bugs in image transforms

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/geometry/matrix.dart
+++ b/packages/vector_graphics_compiler/lib/src/geometry/matrix.dart
@@ -68,46 +68,14 @@ class AffineMatrix {
     );
   }
 
-  /// Create a new [AffineMatrix] with the translation components, if any,
-  /// removed.
-  AffineMatrix removeTranslation() {
-    return AffineMatrix(
-      a,
-      b,
-      c,
-      d,
-      0,
-      0,
-      _m4_10,
-    );
-  }
-
-  /// Return the x, y scale transform as a point if possible.
-  Point? getScale() {
-    if (b == 0.0 && c == 0.0 && _m4_10 == a) {
-      return Point(a, d);
-    }
-    return null;
-  }
-
-  /// Return a new [AffineMatrix] with any scaling removed, if possible.
-  AffineMatrix? removeScale() {
-    if (a == 1.0 && b == 1.0 && _m4_10 == 1.0) {
-      return this;
-    }
-    if (b == 0.0 && c == 0.0 && _m4_10 == a) {
-      return AffineMatrix(
-        1.0,
-        b,
-        c,
-        1.0,
-        e,
-        f,
-        1.0,
-      );
-    }
-    // Non-trivial transform.
-    return null;
+  /// Whether this matrix can be expressed be applied to a rect without any loss
+  /// of inforamtion.
+  ///
+  /// In other words, if this matrix is a simple translate and/or non-negative
+  /// scale with no rotation or skew, this property is true. Otherwise, it is
+  /// false.
+  bool get encodableInRect {
+    return a > 0 && b == 0 && c == 0 && d > 0 && _m4_10 == a;
   }
 
   /// Creates a new affine matrix rotated by `x` and `y`.

--- a/packages/vector_graphics_compiler/test/matrix_test.dart
+++ b/packages/vector_graphics_compiler/test/matrix_test.dart
@@ -125,29 +125,17 @@ void main() {
     expect(matrixA.hashCode != matrixB.hashCode, true);
   });
 
-  test('removeTranslation', () {
-    final AffineMatrix matrixA = AffineMatrix.identity.translated(1, 3);
-    final AffineMatrix matrixB = AffineMatrix.identity.translated(0, 3);
-    final AffineMatrix matrixC =
-        AffineMatrix.identity.translated(1, 3).scaled(10);
+  test('encodableInRect', () {
+    final AffineMatrix matrixA = AffineMatrix.identity.scaled(2, 3);
+    final AffineMatrix matrixB = AffineMatrix.identity.scaled(2, -2);
+    final AffineMatrix matrixC = AffineMatrix.identity.xSkewed(5);
+    final AffineMatrix matrixD = AffineMatrix.identity.ySkewed(5);
+    final AffineMatrix matrixE = AffineMatrix.identity.rotated(1.3);
 
-    expect(matrixA.removeTranslation(), AffineMatrix.identity);
-    expect(matrixB.removeTranslation(), AffineMatrix.identity);
-    expect(matrixC.removeTranslation(), AffineMatrix.identity.scaled(10));
-    expect(AffineMatrix.identity.removeTranslation(), AffineMatrix.identity);
-  });
-
-  test('removeScale', () {
-    final AffineMatrix matrixA = AffineMatrix.identity.scaled(2);
-    final AffineMatrix matrixB = AffineMatrix.identity.scaled(2, 3);
-    final AffineMatrix matrixC = AffineMatrix.identity.xSkewed(2);
-    final AffineMatrix matrixD = AffineMatrix.identity.ySkewed(2);
-    final AffineMatrix matrixE = AffineMatrix.identity.rotated(math.pi);
-
-    expect(matrixA.removeScale(), AffineMatrix.identity);
-    expect(matrixB.removeScale(), AffineMatrix.identity);
-    expect(matrixC.removeScale(), null);
-    expect(matrixD.removeScale(), null);
-    expect(matrixE.removeScale(), null);
+    expect(matrixA.encodableInRect, true);
+    expect(matrixB.encodableInRect, false);
+    expect(matrixC.encodableInRect, false);
+    expect(matrixD.encodableInRect, false);
+    expect(matrixE.encodableInRect, false);
   });
 }

--- a/packages/vector_graphics_compiler/test/resolver_test.dart
+++ b/packages/vector_graphics_compiler/test/resolver_test.dart
@@ -100,4 +100,21 @@ void main() {
 
     expect(visitCount, 2);
   });
+
+  test('Image transform', () async {
+    final Node node = await parseToNodeTree('''
+<svg width="100" height="100" viewBox="0 0 100 100"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <image xlink:href="data:image/png;base64,iVBO" transform="scale(1 -1) translate(50, -50)" x="0" y="0" width="50" height="50"/>
+</svg>''');
+    final Node resolvedNode =
+        node.accept(ResolvingVisitor(), AffineMatrix.identity);
+    final ResolvedImageNode imageNode =
+        queryChildren<ResolvedImageNode>(resolvedNode).single;
+    expect(
+      imageNode.transform,
+      const AffineMatrix(1.0, 0.0, 0.0, -1.0, 50.0, 50.0),
+    );
+  });
 }


### PR DESCRIPTION
See https://github.com/dnfield/flutter_svg/pull/790

While looking into that, I found some bugs in the way we were calculating whether we can use a simple rect to draw the image if it has a transform on it - one was that we weren't looking at the scale value we thought we were, and the other is that we were treating negative scaling as simple (when that should flip the image in a way Flutter can't express for drawImageRect).  I simplified the matrix methods down to a single getter.