### PR TITLE
fix bounds of saveLayer

### DIFF
--- a/packages/vector_graphics/lib/src/render_vector_graphic.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphic.dart
@@ -439,7 +439,7 @@ class RenderPictureVectorGraphic extends RenderBox {
       context.canvas.translate(offset.dx, offset.dy);
     }
     if (_opacityValue != 1.0 || colorFilter != null) {
-      context.canvas.saveLayer(offset & size, colorPaint);
+      context.canvas.saveLayer(Offset.zero & size, colorPaint);
     }
     context.canvas.drawPicture(pictureInfo.picture);
     context.canvas.restoreToCount(saveCount);


### PR DESCRIPTION
Without this a SvgPicture that has a non-zero offset would be transformed twice.

