### PR TITLE
Allow build context to be nullable

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -43,7 +43,7 @@ class NetworkSvgLoader extends BytesLoader {
   final String url;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return await compute((String svgUrl) async {
       final http.Response request = await http.get(Uri.parse(svgUrl));
       final TimelineTask task = TimelineTask()..start('encodeSvg');

--- a/packages/vector_graphics/example/lib/svg_string.dart
+++ b/packages/vector_graphics/example/lib/svg_string.dart
@@ -139,7 +139,7 @@ class RawBytesLoader extends BytesLoader {
   final ByteData data;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return data;
   }
 

--- a/packages/vector_graphics/lib/src/vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/vector_graphics.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:typed_data';
 import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 
@@ -558,12 +559,14 @@ class VectorGraphicUtilities {
   /// they are done with it.
   Future<PictureInfo> loadPicture(
     BytesLoader loader,
-    BuildContext context,
+    BuildContext? context,
   ) async {
-    // This intentionally does not use the picture cache so that disposal does not
-    // happen automatically.
-    final Locale? locale = Localizations.maybeLocaleOf(context);
-    final TextDirection? textDirection = Directionality.maybeOf(context);
+    TextDirection textDirection = TextDirection.ltr;
+    Locale locale = ui.PlatformDispatcher.instance.locale;
+    if (context != null) {
+      locale = Localizations.maybeLocaleOf(context) ?? locale;
+      textDirection = Directionality.maybeOf(context) ?? textDirection;
+    }
     return loader.loadBytes(context).then((ByteData data) {
       try {
         return decodeVectorGraphics(

--- a/packages/vector_graphics/test/caching_test.dart
+++ b/packages/vector_graphics/test/caching_test.dart
@@ -308,7 +308,7 @@ class TestBytesLoader extends BytesLoader {
   final ByteData data;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return data;
   }
 
@@ -327,7 +327,7 @@ class ControlledAssetBytesLoader extends AssetBytesLoader {
   final Completer<void> completer = Completer<void>();
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     await completer.future;
     return super.loadBytes(context);
   }

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -406,7 +406,8 @@ void main() {
     expect(debugLastTextDirection, TextDirection.rtl);
   });
 
-  testWidgets('Loads a picture with loadPicture and null build context', (WidgetTester tester) async {
+  testWidgets('Loads a picture with loadPicture and null build context',
+      (WidgetTester tester) async {
     final TestAssetBundle testBundle = TestAssetBundle();
     final Completer<PictureInfo> completer = Completer<PictureInfo>();
     await tester.pumpWidget(
@@ -421,7 +422,9 @@ void main() {
             bundle: testBundle,
             child: Builder(builder: (BuildContext context) {
               vg
-                  .loadPicture(AssetBytesLoader('foo.svg', assetBundle: testBundle), null)
+                  .loadPicture(
+                      AssetBytesLoader('foo.svg', assetBundle: testBundle),
+                      null)
                   .then(completer.complete);
               return const Center();
             }),

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -406,6 +406,36 @@ void main() {
     expect(debugLastTextDirection, TextDirection.rtl);
   });
 
+  testWidgets('Loads a picture with loadPicture and null build context', (WidgetTester tester) async {
+    final TestAssetBundle testBundle = TestAssetBundle();
+    final Completer<PictureInfo> completer = Completer<PictureInfo>();
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const <LocalizationsDelegate<Object>>[
+          DefaultWidgetsLocalizations.delegate
+        ],
+        locale: const Locale('fr', 'CH'),
+        child: Directionality(
+          textDirection: TextDirection.rtl,
+          child: DefaultAssetBundle(
+            bundle: testBundle,
+            child: Builder(builder: (BuildContext context) {
+              vg
+                  .loadPicture(AssetBytesLoader('foo.svg', assetBundle: testBundle), null)
+                  .then(completer.complete);
+              return const Center();
+            }),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(await completer.future, isA<PictureInfo>());
+    expect(debugLastLocale, PlatformDispatcher.instance.locale);
+    expect(debugLastTextDirection, TextDirection.ltr);
+  });
+
   testWidgets('Throws a helpful exception if decoding fails',
       (WidgetTester tester) async {
     final Uint8List data = Uint8List(256);
@@ -507,7 +537,7 @@ class DelayedBytesLoader extends BytesLoader {
   final Future<ByteData> data;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return await data;
   }
 
@@ -527,7 +557,7 @@ class TestBytesLoader extends BytesLoader {
   final String? source;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return data;
   }
 

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -19,7 +19,7 @@ class TestBytesLoader extends BytesLoader {
   final ByteData data;
 
   @override
-  Future<ByteData> loadBytes(BuildContext context) async {
+  Future<ByteData> loadBytes(BuildContext? context) async {
     return data;
   }
 


### PR DESCRIPTION
It's reasonable to want to load a vector graphic from a location where you have no build context but do have an asset bundle etc.