### PR TITLE
Allow compile-time color remapping.

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/color_mapper.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/color_mapper.dart
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../paint.dart';
+
+/// A class that transforms from one color to another during SVG parsing.
+abstract class ColorMapper {
+  /// Returns a new color to use in place of [color] during SVG parsing.
+  ///
+  /// The SVG parser will call this method every time it parses a color
+  Color substitute(
+    String? id,
+    String elementName,
+    String attributeName,
+    Color color,
+  );
+}

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -11,6 +11,7 @@ import 'src/geometry/image.dart';
 import 'src/geometry/vertices.dart';
 import 'src/geometry/path.dart';
 import 'src/paint.dart';
+import 'src/svg/color_mapper.dart';
 import 'src/svg/theme.dart';
 import 'src/svg/parser.dart';
 import 'src/vector_instructions.dart';
@@ -20,6 +21,7 @@ export 'src/geometry/matrix.dart';
 export 'src/geometry/path.dart';
 export 'src/geometry/vertices.dart';
 export 'src/paint.dart';
+export 'src/svg/color_mapper.dart';
 export 'src/svg/theme.dart';
 export 'src/svg/resolver.dart';
 export 'src/vector_instructions.dart';
@@ -59,8 +61,15 @@ Future<VectorInstructions> parse(
   bool enableMaskingOptimizer = true,
   bool enableClippingOptimizer = true,
   bool enableOverdrawOptimizer = true,
+  ColorMapper? colorMapper,
 }) async {
-  final SvgParser parser = SvgParser(xml, theme, key, warningsAsErrors);
+  final SvgParser parser = SvgParser(
+    xml,
+    theme,
+    key,
+    warningsAsErrors,
+    colorMapper,
+  );
   parser.enableMaskingOptimizer = enableMaskingOptimizer;
   parser.enableClippingOptimizer = enableClippingOptimizer;
   parser.enableOverdrawOptimizer = enableOverdrawOptimizer;
@@ -127,6 +136,7 @@ Future<Uint8List> encodeSvg({
   bool enableClippingOptimizer = true,
   bool enableOverdrawOptimizer = true,
   bool warningsAsErrors = false,
+  ColorMapper? colorMapper,
 }) async {
   const VectorGraphicsCodec codec = VectorGraphicsCodec();
   final VectorInstructions instructions = await parse(
@@ -137,6 +147,7 @@ Future<Uint8List> encodeSvg({
     enableClippingOptimizer: enableClippingOptimizer,
     enableOverdrawOptimizer: enableOverdrawOptimizer,
     warningsAsErrors: warningsAsErrors,
+    colorMapper: colorMapper,
   );
 
   final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();


### PR DESCRIPTION
This allows unrestricted changes to colors at parse time.

We could potentially have a similar interface (although with less information) at runtime rendering, although there we would have to restrict changes to alpha since optimizations done in the compiler may have made alpha changes cause visual breakage.