### PR TITLE
Make parsing synchronous?

### DIFF
--- a/packages/vector_graphics_compiler/test/clipping_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/clipping_optimizer_test.dart
@@ -10,7 +10,7 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 Future<Node> parseAndResolve(String source) async {
-  final Node node = await parseToNodeTree(source);
+  final Node node = parseToNodeTree(source);
   final ResolvingVisitor visitor = ResolvingVisitor();
   return node.accept(visitor, AffineMatrix.identity);
 }

--- a/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
@@ -13,7 +13,7 @@ import 'helpers.dart';
 import 'test_svg_strings.dart';
 
 Future<Node> parseAndResolve(String source) async {
-  final Node node = await parseToNodeTree(source);
+  final Node node = parseToNodeTree(source);
   final ResolvingVisitor visitor = ResolvingVisitor();
   return node.accept(visitor, AffineMatrix.identity);
 }

--- a/packages/vector_graphics_compiler/test/opacity_peephole_test.dart
+++ b/packages/vector_graphics_compiler/test/opacity_peephole_test.dart
@@ -13,7 +13,7 @@ import 'package:vector_graphics_compiler/src/svg/resolver.dart';
 import 'helpers.dart';
 
 Future<Node> parseAndResolve(String source) async {
-  final Node node = await parseToNodeTree(source);
+  final Node node = parseToNodeTree(source);
   final ResolvingVisitor visitor = ResolvingVisitor();
   return node.accept(visitor, AffineMatrix.identity);
 }

--- a/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/overdraw_optimizer_test.dart
@@ -11,7 +11,7 @@ import 'helpers.dart';
 import 'test_svg_strings.dart';
 
 Future<Node> parseAndResolve(String source) async {
-  final Node node = await parseToNodeTree(source);
+  final Node node = parseToNodeTree(source);
   final ResolvingVisitor visitor = ResolvingVisitor();
   return node.accept(visitor, AffineMatrix.identity);
 }

--- a/packages/vector_graphics_compiler/test/parsers_test.dart
+++ b/packages/vector_graphics_compiler/test/parsers_test.dart
@@ -36,7 +36,7 @@ void main() {
       ..enableMaskingOptimizer = false
       ..enableClippingOptimizer = false
       ..enableOverdrawOptimizer = false;
-    final VectorInstructions instructions = await parser.parse();
+    final VectorInstructions instructions = parser.parse();
 
     // TestMapper just always returns this color.
     expect(instructions.paints.single.fill!.color,

--- a/packages/vector_graphics_compiler/test/resolver_test.dart
+++ b/packages/vector_graphics_compiler/test/resolver_test.dart
@@ -17,7 +17,7 @@ void main() {
   test(
       'Resolves PathNodes to ResolvedPathNodes by flattening the transform '
       'and computing bounds', () async {
-    final Node node = await parseToNodeTree('''
+    final Node node = parseToNodeTree('''
 <svg viewBox="0 0 200 200">
   <g transform="translate(10, 10)">
     <rect x="0" y="0" width="10" height="10" fill="white" />
@@ -48,7 +48,7 @@ void main() {
   });
 
   test('Resolving Nodes replaces empty text with Node.zero', () async {
-    final Node node = await parseToNodeTree('''
+    final Node node = parseToNodeTree('''
   <svg viewBox="0 0 200 200">
     <text></text>
   </svg>''');
@@ -61,7 +61,7 @@ void main() {
   });
 
   test('Resolving Nodes removes unresolved masks', () async {
-    final Node node = await parseToNodeTree('''
+    final Node node = parseToNodeTree('''
 <svg viewBox="0 0 200 200">
   <g mask="foo">
     <rect x="0" y="0" width="100" height="100" fill="white" />
@@ -102,7 +102,7 @@ void main() {
   });
 
   test('Image transform', () async {
-    final Node node = await parseToNodeTree('''
+    final Node node = parseToNodeTree('''
 <svg width="100" height="100" viewBox="0 0 100 100"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/vector_graphics_compiler/test/tessellator_test.dart
+++ b/packages/vector_graphics_compiler/test/tessellator_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   test('Can convert simple shape to indexed vertices', () async {
-    final Node node = await parseToNodeTree('''
+    final Node node = parseToNodeTree('''
 <svg viewBox="0 0 200 200">
   <rect x="0" y="0" width="10" height="10" fill="white" />
 </svg>''');


### PR DESCRIPTION
flutter_svg did async parsing because it potentially would do image fetching from the network and/or decoding of images during parsing. I think I had some idea that this might allow it to be interruptible somehow, although I don't think that ever actually worked in practice.

There's no good reason right now to have the compiler do async parsing, _however_ this will make things problematic if we ever need to support network based images (which currently don't work).

I'm hesitant about this change because it will be difficult to undo if we ever need to go back to async. But we could also require that callers provide an image resolver if they want to resolve network images, perhaps with some preprocessing step that would provide the URLs from the SVG that need to be fetched, and force people who really want this to opt into it while still having synchronous parsing.