### PR TITLE
Fix ordering of matrix operations for multi-argument `rotate` followed by additional matrix operations

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
@@ -26,8 +26,6 @@ const Map<String, _MatrixParser> _matrixParsers = <String, _MatrixParser>{
 };
 
 /// Parses a SVG transform attribute into a [AffineMatrix].
-///
-/// Also adds [x] and [y] to append as a final translation, e.g. for `<use>`.
 AffineMatrix? parseTransform(String? transform) {
   if (transform == null || transform == '') {
     return null;
@@ -108,9 +106,9 @@ AffineMatrix _parseSvgRotate(String? paramsStr, AffineMatrix current) {
     final double x = parseDouble(params[1])!;
     final double y = params.length == 3 ? parseDouble(params[2])! : x;
     return AffineMatrix(1.0, 0.0, 0.0, 1.0, x, y)
-        .multiplied(current)
         .multiplied(rotate)
-        .translated(-x, -y);
+        .translated(-x, -y)
+        .multiplied(current);
   } else {
     return rotate.multiplied(current);
   }

--- a/packages/vector_graphics_compiler/test/matrix_test.dart
+++ b/packages/vector_graphics_compiler/test/matrix_test.dart
@@ -4,12 +4,26 @@
 
 import 'dart:math' as math;
 
+import 'package:vector_graphics_compiler/src/svg/parsers.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 void main() {
+  test('Parse rotate and scale', () {
+    // Regression test for https://github.com/dnfield/flutter_svg/issues/801
+    final AffineMatrix mat = parseTransform('rotate(-1 4 -12) scale(2)')!;
+    expect(
+      mat,
+      AffineMatrix.identity
+          .translated(4, -12)
+          .rotated(radians(-1))
+          .translated(-4, 12)
+          .scaled(2),
+    );
+  });
+
   test('Identity matrix', () {
     expect(AffineMatrix.identity.toMatrix4(), Matrix4.identity().storage);
   });


### PR DESCRIPTION
Fixes dnfield/flutter_svg#801