### PR TITLE
Respect packageName in AssetBytesLoader

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.1+1
+
+- Fix bug in asset loading from packages.
+
 ## 1.0.1
 
 - Fix handling of fill colors on use/group elements.

--- a/packages/vector_graphics/lib/src/loader.dart
+++ b/packages/vector_graphics/lib/src/loader.dart
@@ -78,7 +78,9 @@ class AssetBytesLoader extends BytesLoader {
 
   @override
   Future<ByteData> loadBytes(BuildContext? context) {
-    return _resolveBundle(context).load(assetName);
+    return _resolveBundle(context).load(
+      packageName == null ? assetName : 'packages/$packageName/$assetName',
+    );
   }
 
   @override

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics
 description: A vector graphics rendering package for Flutter.
-version: 1.0.1
+version: 1.0.1+1
 homepage: https://github.com/dnfield/vector_graphics
 
 environment:

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -588,6 +588,30 @@ void main() {
       matchesGoldenFile('vg_with_image_blue.png'),
     );
   }, skip: kIsWeb);
+
+  test('AssetBytesLoader respects packages', () async {
+    final TestBundle bundle = TestBundle(<String, ByteData>{
+      'foo': Uint8List(0).buffer.asByteData(),
+      'packages/packageName/foo': Uint8List(1).buffer.asByteData(),
+    });
+    final AssetBytesLoader loader =
+        AssetBytesLoader('foo', assetBundle: bundle);
+    final AssetBytesLoader packageLoader = AssetBytesLoader('foo',
+        assetBundle: bundle, packageName: 'packageName');
+    expect((await loader.loadBytes(null)).lengthInBytes, 0);
+    expect((await packageLoader.loadBytes(null)).lengthInBytes, 1);
+  });
+}
+
+class TestBundle extends Fake implements AssetBundle {
+  TestBundle(this.map);
+
+  final Map<String, ByteData> map;
+
+  @override
+  Future<ByteData> load(String key) async {
+    return map[key]!;
+  }
 }
 
 class TestAssetBundle extends Fake implements AssetBundle {


### PR DESCRIPTION
Apply the same changes from https://github.com/dnfield/flutter_svg/pull/838 to  `AssetBytesLoader`