### PR TITLE
Reintroduce clipBehavior

### DIFF
--- a/packages/vector_graphics/lib/src/vector_graphics.dart
+++ b/packages/vector_graphics/lib/src/vector_graphics.dart
@@ -53,6 +53,7 @@ VectorGraphic createCompatVectorGraphic({
   AlignmentGeometry alignment = Alignment.center,
   String? semanticsLabel,
   bool excludeFromSemantics = false,
+  Clip clipBehavior = Clip.hardEdge,
   WidgetBuilder? placeholderBuilder,
   ColorFilter? colorFilter,
   Animation<double>? opacity,
@@ -68,6 +69,7 @@ VectorGraphic createCompatVectorGraphic({
     alignment: alignment,
     semanticsLabel: semanticsLabel,
     excludeFromSemantics: excludeFromSemantics,
+    clipBehavior: clipBehavior,
     placeholderBuilder: placeholderBuilder,
     colorFilter: colorFilter,
     opacity: opacity,
@@ -101,6 +103,7 @@ class VectorGraphic extends StatefulWidget {
     this.alignment = Alignment.center,
     this.semanticsLabel,
     this.excludeFromSemantics = false,
+    this.clipBehavior = Clip.hardEdge,
     this.placeholderBuilder,
     this.colorFilter,
     this.opacity,
@@ -117,6 +120,7 @@ class VectorGraphic extends StatefulWidget {
     this.alignment = Alignment.center,
     this.semanticsLabel,
     this.excludeFromSemantics = false,
+    this.clipBehavior = Clip.hardEdge,
     this.placeholderBuilder,
     this.colorFilter,
     this.opacity,
@@ -178,6 +182,14 @@ class VectorGraphic extends StatefulWidget {
   /// Useful for pictures which do not contribute meaningful semantic information to an
   /// application.
   final bool excludeFromSemantics;
+
+  /// The content will be clipped (or not) according to this option.
+  ///
+  /// See the enum [Clip] for details of all possible options and their common
+  /// use cases.
+  ///
+  /// Defaults to [Clip.hardEdge], and must not be null.
+  final Clip clipBehavior;
 
   /// The placeholder to use while fetching, decoding, and parsing the vector_graphics data.
   final WidgetBuilder? placeholderBuilder;
@@ -430,7 +442,7 @@ class _VectorGraphicWidgetState extends State<VectorGraphic> {
         child: FittedBox(
           fit: widget.fit,
           alignment: widget.alignment,
-          clipBehavior: Clip.hardEdge,
+          clipBehavior: widget.clipBehavior,
           child: SizedBox.fromSize(
             size: pictureInfo.size,
             child: renderWidget,

--- a/packages/vector_graphics/test/vector_graphics_test.dart
+++ b/packages/vector_graphics/test/vector_graphics_test.dart
@@ -159,6 +159,41 @@ void main() {
     expect(fittedBox.clipBehavior, Clip.hardEdge);
   });
 
+  group('ClipBehavior', () {
+    testWidgets('Sets clipBehavior to hardEdge if not provided',
+        (WidgetTester tester) async {
+      final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
+      await tester.pumpWidget(VectorGraphic(
+        loader: TestBytesLoader(buffer.done()),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FittedBox), findsOneWidget);
+
+      final FittedBox fittedBox =
+          (find.byType(FittedBox).evaluate().first.widget as FittedBox);
+
+      expect(fittedBox.clipBehavior, Clip.hardEdge);
+    });
+
+    testWidgets('Passes clipBehavior to FittedBox if provided',
+        (WidgetTester tester) async {
+      final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();
+      await tester.pumpWidget(VectorGraphic(
+        loader: TestBytesLoader(buffer.done()),
+        clipBehavior: Clip.none,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FittedBox), findsOneWidget);
+
+      final FittedBox fittedBox =
+          (find.byType(FittedBox).evaluate().first.widget as FittedBox);
+
+      expect(fittedBox.clipBehavior, Clip.none);
+    });
+  });
+
   testWidgets('Sizes VectorGraphic based on encoded viewbox information',
       (WidgetTester tester) async {
     final VectorGraphicsBuffer buffer = VectorGraphicsBuffer();


### PR DESCRIPTION
clipBehavior was deprecated in 2.0.0 without any notice in the changelog. It still works fine so this PR reintroduces the parameter.