### PR TITLE
correctly handle opacity and blending when in a saveLayer

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1969,6 +1969,39 @@ class SvgAttributes {
   /// The y translation.
   final double? y;
 
+  /// A copy of these attributes after absorbing a saveLayer.
+  ///
+  /// Specifically, this will null out `blendMode` and any opacity related
+  /// attributes, since those have been applied in a saveLayer call.
+  ///
+  /// The [raw] map preserves old values.
+  SvgAttributes forSaveLayer() {
+    return SvgAttributes._(
+      raw: raw,
+      id: id,
+      href: href,
+      transform: transform,
+      color: color,
+      stroke: stroke?.forSaveLayer(),
+      fill: fill?.forSaveLayer(),
+      fillRule: fillRule,
+      clipRule: clipRule,
+      clipPathId: clipPathId,
+      blendMode: blendMode,
+      fontFamily: fontFamily,
+      fontWeight: fontWeight,
+      fontSize: fontSize,
+      textDecoration: textDecoration,
+      textDecorationStyle: textDecorationStyle,
+      textDecorationColor: textDecorationColor,
+      x: x,
+      textAnchorMultiplier: textAnchorMultiplier,
+      y: y,
+      width: width,
+      height: height,
+    );
+  }
+
   /// Creates a new set of attributes as if this inherited from `parent`.
   ///
   /// If `includePosition` is true, the `x`/`y` coordinates are also inherited. This
@@ -2066,6 +2099,25 @@ class SvgStrokeAttributes {
   /// The opacity to apply to a default color, if [color] is null.
   final double? opacity;
 
+  /// A copy of these attributes after absorbing a saveLayer.
+  ///
+  /// Specifically, this will null out any opacity related
+  /// attributes, since those have been applied in a saveLayer call.
+  SvgStrokeAttributes forSaveLayer() {
+    return SvgStrokeAttributes._(
+      _definitions,
+      color: color,
+      shaderId: shaderId,
+      join: join,
+      cap: cap,
+      miterLimit: miterLimit,
+      width: width,
+      dashArray: dashArray,
+      dashOffset: dashOffset,
+      hasPattern: hasPattern,
+    );
+  }
+
   /// Inherits attributes in this from parent.
   SvgStrokeAttributes applyParent(SvgStrokeAttributes? parent) {
     return SvgStrokeAttributes._(
@@ -2155,6 +2207,19 @@ class SvgFillAttributes {
 
   /// If there is a pattern a default fill will be returned.
   final bool? hasPattern;
+
+  /// A copy of these attributes after absorbing a saveLayer.
+  ///
+  /// Specifically, this will null out any opacity related
+  /// attributes, since those have been applied in a saveLayer call.
+  SvgFillAttributes forSaveLayer() {
+    return SvgFillAttributes._(
+      _definitions,
+      color: color,
+      shaderId: shaderId,
+      hasPattern: hasPattern,
+    );
+  }
 
   /// Inherits attributes in this from parent.
   SvgFillAttributes applyParent(SvgFillAttributes? parent) {

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -76,7 +76,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
         children: <Node>[
           for (Node child in parentNode.children)
             child
-                .applyAttributes(parentNode.attributes)
+                .applyAttributes(parentNode.attributes.forSaveLayer())
                 .accept(this, nextTransform),
         ],
       );

--- a/packages/vector_graphics_compiler/test/resolver_test.dart
+++ b/packages/vector_graphics_compiler/test/resolver_test.dart
@@ -48,7 +48,8 @@ void main() {
         node.accept(ResolvingVisitor(), AffineMatrix.identity);
     final List<ResolvedPathNode> nodes =
         queryChildren<ResolvedPathNode>(resolvedNode);
-    final SaveLayerNode saveLayerNode = queryChildren<SaveLayerNode>(resolvedNode).single;
+    final SaveLayerNode saveLayerNode =
+        queryChildren<SaveLayerNode>(resolvedNode).single;
 
     expect(saveLayerNode.paint.fill!.color, const Color(0x7FFF0000));
 

--- a/packages/vector_graphics_compiler/test/resolver_test.dart
+++ b/packages/vector_graphics_compiler/test/resolver_test.dart
@@ -40,23 +40,28 @@ void main() {
     final Node node = parseToNodeTree('''
 <svg viewBox="0 0 200 200">
   <g opacity=".5" fill="red">
-    <rect x="0" y="0" width="10" height="10" />
-    <rect x="5" y="5" width="10" height="10" />
+    <rect x="0" y="0" width="100" height="100" />
+    <rect x="50" y="50" width="100" height="100" />
   </g>
 </svg>''');
     final Node resolvedNode =
         node.accept(ResolvingVisitor(), AffineMatrix.identity);
     final List<ResolvedPathNode> nodes =
         queryChildren<ResolvedPathNode>(resolvedNode);
+    final SaveLayerNode saveLayerNode = queryChildren<SaveLayerNode>(resolvedNode).single;
+
+    expect(saveLayerNode.paint.fill!.color, const Color(0x7FFF0000));
 
     expect(nodes.length, 2);
+
+    // Opacity is not inherited since it is applied in a saveLayer.
     expect(
       nodes.first.paint,
-      const Paint(fill: Fill(color: Color(0x7FFF0000))),
+      const Paint(fill: Fill(color: Color(0xFFFF0000))),
     );
     expect(
       nodes.last.paint,
-      const Paint(fill: Fill(color: Color(0x7FFF0000))),
+      const Paint(fill: Fill(color: Color(0xFFFF0000))),
     );
   });
 


### PR DESCRIPTION
We can't inherit opacity or blend mode in cases where we decided to save those values into a new layer.