### PR TITLE
Fix text parsing

### DIFF
--- a/packages/vector_graphics/example/lib/svg_string.dart
+++ b/packages/vector_graphics/example/lib/svg_string.dart
@@ -72,8 +72,9 @@ class _MyAppState extends State<MyApp> {
           _gzVgLength = gzip.encode(data.buffer.asUint8List()).length;
           _data = data;
         });
-      }, onError: (Object error) {
+      }, onError: (Object error, StackTrace stack) {
         debugPrint(error.toString());
+        debugPrint(stack.toString());
       });
     });
   }

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -242,12 +242,17 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   final List<Path> _paths = <Path>[];
   final List<Shader> _shaders = <Shader>[];
   final List<_TextConfig> _textConfig = <_TextConfig>[];
+  final List<_TextPosition> _textPositions = <_TextPosition>[];
   final List<Future<void>> _pendingImages = <Future<void>>[];
   final Map<int, Image> _images = <int, Image>{};
   final Map<int, _PatternState> _patterns = <int, _PatternState>{};
   Path? _currentPath;
   Size _size = Size.zero;
   bool _done = false;
+
+  double? _accumulatedTextPositionX;
+  double _textPositionY = 0;
+  Float64List? _textTransform;
 
   _PatternConfig? _currentPattern;
 
@@ -555,15 +560,12 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   void onTextConfig(
     String text,
     String? fontFamily,
-    double x,
     double xAnchorMultiplier,
-    double y,
     int fontWeight,
     double fontSize,
     int decoration,
     int decorationStyle,
     int decorationColor,
-    Float64List? transform,
     int id,
   ) {
     final List<TextDecoration> decorations = <TextDecoration>[];
@@ -580,63 +582,117 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     _textConfig.add(_TextConfig(
       text,
       fontFamily,
-      x,
       xAnchorMultiplier,
-      y,
       FontWeight.values[fontWeight],
       fontSize,
       TextDecoration.combine(decorations),
       TextDecorationStyle.values[decorationStyle],
       Color(decorationColor),
-      transform,
     ));
   }
 
   @override
-  void onDrawText(int textId, int paintId, int? patternId) async {
-    final Paint paint = _paints[paintId];
-    if (patternId != null) {
-      paint.shader = _patterns[patternId]!.shader;
+  void onTextPosition(
+    int textPositionId,
+    double? x,
+    double? y,
+    double? dx,
+    double? dy,
+    bool reset,
+    Float64List? transform,
+  ) {
+    _textPositions.add(_TextPosition(x, y, dx, dy, reset, transform));
+  }
+
+  @override
+  void onUpdateTextPosition(int textPositionId) {
+    final _TextPosition position = _textPositions[textPositionId];
+    if (position.reset) {
+      _accumulatedTextPositionX = 0;
+      _textPositionY = 0;
     }
+
+    if (position.x != null) {
+      _accumulatedTextPositionX = position.x;
+    }
+    if (position.y != null) {
+      _textPositionY = position.y ?? _textPositionY;
+    }
+
+    if (position.dx != null) {
+      _accumulatedTextPositionX =
+          (_accumulatedTextPositionX ?? 0) + position.dx!;
+    }
+    if (position.dy != null) {
+      _textPositionY = _textPositionY + position.dy!;
+    }
+
+    _textTransform = position.transform;
+  }
+
+  @override
+  void onDrawText(
+    int textId,
+    int? fillId,
+    int? strokeId,
+    int? patternId,
+  ) async {
     final _TextConfig textConfig = _textConfig[textId];
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
-      textDirection: _textDirection,
-    ));
-    builder.pushStyle(TextStyle(
-      locale: _locale,
-      foreground: paint,
-      fontWeight: textConfig.fontWeight,
-      fontSize: textConfig.fontSize,
-      fontFamily: textConfig.fontFamily,
-      decoration: textConfig.decoration,
-      decorationStyle: textConfig.decorationStyle,
-      decorationColor: textConfig.decorationColor,
-    ));
-    // if (textConfig.text == 'Line 3') {
-    //   builder.addPlaceholder(22.0 * 'Stroked bold line'.length, 16, PlaceholderAlignment.bottom);
-    // }
-    builder.addText(textConfig.text);
+    final double dx = _accumulatedTextPositionX ?? 0;
+    final double dy = _textPositionY;
+    double paragraphWidth = 0;
 
-    final Paragraph paragraph = builder.build();
-    paragraph.layout(const ParagraphConstraints(
-      width: double.infinity,
-    ));
+    void _draw(int paintId) {
+      final Paint paint = _paints[paintId];
+      if (patternId != null) {
+        paint.shader = _patterns[patternId]!.shader;
+      }
+      final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+        textDirection: _textDirection,
+      ));
+      builder.pushStyle(TextStyle(
+        locale: _locale,
+        foreground: paint,
+        fontWeight: textConfig.fontWeight,
+        fontSize: textConfig.fontSize,
+        fontFamily: textConfig.fontFamily,
+        decoration: textConfig.decoration,
+        decorationStyle: textConfig.decorationStyle,
+        decorationColor: textConfig.decorationColor,
+      ));
 
-    if (textConfig.transform != null) {
-      _canvas.save();
-      _canvas.transform(textConfig.transform!);
+      builder.addText(textConfig.text);
+
+      final Paragraph paragraph = builder.build();
+      paragraph.layout(const ParagraphConstraints(
+        width: double.infinity,
+      ));
+      paragraphWidth = paragraph.maxIntrinsicWidth;
+
+      if (_textTransform != null) {
+        _canvas.save();
+        _canvas.transform(_textTransform!);
+      }
+      _canvas.drawParagraph(
+        paragraph,
+        Offset(
+          dx - paragraph.maxIntrinsicWidth * textConfig.xAnchorMultiplier,
+          dy - paragraph.alphabeticBaseline,
+        ),
+      );
+      paragraph.dispose();
+      if (_textTransform != null) {
+        _canvas.restore();
+      }
     }
-    _canvas.drawParagraph(
-      paragraph,
-      Offset(
-        textConfig.dx - paragraph.longestLine * textConfig.xAnchorMultiplier,
-        textConfig.dy - paragraph.alphabeticBaseline,
-      ),
-    );
-    paragraph.dispose();
-    if (textConfig.transform != null) {
-      _canvas.restore();
+
+    if (fillId != null) {
+      _draw(fillId);
     }
+    if (strokeId != null) {
+      _draw(strokeId);
+    }
+    _accumulatedTextPositionX = dx + paragraphWidth;
   }
 
   int _createImageKey(int imageId, int format) {
@@ -700,32 +756,44 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 }
 
+class _TextPosition {
+  const _TextPosition(
+    this.x,
+    this.y,
+    this.dx,
+    this.dy,
+    this.reset,
+    this.transform,
+  );
+
+  final double? x;
+  final double? y;
+  final double? dx;
+  final double? dy;
+  final bool reset;
+  final Float64List? transform;
+}
+
 class _TextConfig {
   const _TextConfig(
     this.text,
     this.fontFamily,
-    this.dx,
     this.xAnchorMultiplier,
-    this.dy,
     this.fontWeight,
     this.fontSize,
     this.decoration,
     this.decorationStyle,
     this.decorationColor,
-    this.transform,
   );
 
   final String text;
   final String? fontFamily;
   final double fontSize;
-  final double dx;
   final double xAnchorMultiplier;
-  final double dy;
   final FontWeight fontWeight;
   final TextDecoration decoration;
   final TextDecorationStyle decorationStyle;
   final Color decorationColor;
-  final Float64List? transform;
 }
 
 /// An exception thrown if decoding fails.

--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -612,6 +612,9 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       decorationStyle: textConfig.decorationStyle,
       decorationColor: textConfig.decorationColor,
     ));
+    // if (textConfig.text == 'Line 3') {
+    //   builder.addPlaceholder(22.0 * 'Stroked bold line'.length, 16, PlaceholderAlignment.bottom);
+    // }
     builder.addText(textConfig.text);
 
     final Paragraph paragraph = builder.build();

--- a/packages/vector_graphics/test/listener_test.dart
+++ b/packages/vector_graphics/test/listener_test.dart
@@ -137,14 +137,12 @@ void main() {
     final Invocation drawParagraph1 = factory.fakeCanvases.last.invocations[1];
 
     expect(drawParagraph0.memberName, #drawParagraph);
+    // Only checking the X because Y seems to vary a bit by platform within
+    // acceptable range. X is what gets managed by the listener anyway.
     expect((drawParagraph0.positionalArguments[1] as Offset).dx, 10);
-    expect((drawParagraph0.positionalArguments[1] as Offset).dy,
-        closeTo(-2.8, .001));
 
     expect(drawParagraph1.memberName, #drawParagraph);
     expect((drawParagraph1.positionalArguments[1] as Offset).dx, 58);
-    expect((drawParagraph0.positionalArguments[1] as Offset).dy,
-        closeTo(-2.8, .001));
   });
 }
 

--- a/packages/vector_graphics/test/listener_test.dart
+++ b/packages/vector_graphics/test/listener_test.dart
@@ -109,6 +109,45 @@ void main() {
       const ui.Rect.fromLTRB(0, 0, 100, 100),
     );
   });
+
+  test('Text position is respected', () async {
+    final TestPictureFactory factory = TestPictureFactory();
+    final FlutterVectorGraphicsListener listener =
+        FlutterVectorGraphicsListener(
+      pictureFactory: factory,
+    );
+    listener.onPaintObject(
+      color: const ui.Color(0xff000000).value,
+      strokeCap: null,
+      strokeJoin: null,
+      blendMode: BlendMode.srcIn.index,
+      strokeMiterLimit: null,
+      strokeWidth: null,
+      paintStyle: ui.PaintingStyle.fill.index,
+      id: 0,
+      shaderId: null,
+    );
+    listener.onTextPosition(0, 10, 10, null, null, true, null);
+    listener.onUpdateTextPosition(0);
+    listener.onTextConfig('foo', null, 0, 0, 16, 0, 0, 0, 0);
+    listener.onDrawText(0, 0, null, null);
+    listener.onDrawText(0, 0, null, null);
+
+    final Invocation drawParagraph0 = factory.fakeCanvases.last.invocations[0];
+    final Invocation drawParagraph1 = factory.fakeCanvases.last.invocations[1];
+
+    expect(drawParagraph0.memberName, #drawParagraph);
+    expect(
+      drawParagraph0.positionalArguments[1],
+      const Offset(10, -2.800048828125),
+    );
+
+    expect(drawParagraph1.memberName, #drawParagraph);
+    expect(
+      drawParagraph1.positionalArguments[1],
+      const Offset(58, -2.800048828125),
+    );
+  });
 }
 
 class TestPictureFactory implements PictureFactory {

--- a/packages/vector_graphics/test/listener_test.dart
+++ b/packages/vector_graphics/test/listener_test.dart
@@ -137,16 +137,14 @@ void main() {
     final Invocation drawParagraph1 = factory.fakeCanvases.last.invocations[1];
 
     expect(drawParagraph0.memberName, #drawParagraph);
-    expect(
-      drawParagraph0.positionalArguments[1],
-      const Offset(10, -2.800048828125),
-    );
+    expect((drawParagraph0.positionalArguments[1] as Offset).dx, 10);
+    expect((drawParagraph0.positionalArguments[1] as Offset).dy,
+        closeTo(-2.8, .001));
 
     expect(drawParagraph1.memberName, #drawParagraph);
-    expect(
-      drawParagraph1.positionalArguments[1],
-      const Offset(58, -2.800048828125),
-    );
+    expect((drawParagraph1.positionalArguments[1] as Offset).dx, 58);
+    expect((drawParagraph0.positionalArguments[1] as Offset).dy,
+        closeTo(-2.8, .001));
   });
 }
 

--- a/packages/vector_graphics_compiler/lib/src/debug_format.dart
+++ b/packages/vector_graphics_compiler/lib/src/debug_format.dart
@@ -49,8 +49,8 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onDrawText(int textId, int paintId, int? patternId) {
-    buffer.writeln('DrawText: id:$textId ($paintId, $patternId)');
+  void onDrawText(int textId, int? fillId, int? strokeId, int? patternId) {
+    buffer.writeln('DrawText: id:$textId (fill: $fillId, stroke: $strokeId, pattern: $patternId)');
   }
 
   @override
@@ -188,18 +188,34 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
   void onTextConfig(
     String text,
     String? fontFamily,
-    double x,
     double xAnchorMultiplier,
-    double y,
     int fontWeight,
     double fontSize,
     int decoration,
     int decorationStyle,
     int decorationColor,
-    Float64List? transform,
     int id,
   ) {
     buffer.writeln(
-        'RecordText: id:$id ($text, ($x, $y) ($xAnchorMultiplier x-anchoring), weight: $fontWeight, size: $fontSize, decoration: $decoration, decorationStyle: $decorationStyle, decorationColor: 0x${decorationColor.toRadixString(16)}, family: $fontFamily, transform: $transform)');
+        'RecordText: id:$id ($text, ($xAnchorMultiplier x-anchoring), weight: $fontWeight, size: $fontSize, decoration: $decoration, decorationStyle: $decorationStyle, decorationColor: 0x${decorationColor.toRadixString(16)}, family: $fontFamily)');
+  }
+
+  @override
+  void onTextPosition(
+    int id,
+    double? x,
+    double? y,
+    double? dx,
+    double? dy,
+    bool reset,
+    Float64List? transform,
+  ) {
+    buffer.writeln(
+        'StoreTextPosition: id:$id (($x, $y) d($dx, $dy), reset: $reset, transform: $transform)');
+  }
+
+  @override
+  void onUpdateTextPosition(int id) {
+    buffer.writeln('UpdateTextPosition: id:$id');
   }
 }

--- a/packages/vector_graphics_compiler/lib/src/debug_format.dart
+++ b/packages/vector_graphics_compiler/lib/src/debug_format.dart
@@ -50,7 +50,8 @@ class _DebugVectorGraphicsListener extends VectorGraphicsCodecListener {
 
   @override
   void onDrawText(int textId, int? fillId, int? strokeId, int? patternId) {
-    buffer.writeln('DrawText: id:$textId (fill: $fillId, stroke: $strokeId, pattern: $patternId)');
+    buffer.writeln(
+        'DrawText: id:$textId (fill: $fillId, stroke: $strokeId, pattern: $patternId)');
   }
 
   @override

--- a/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
+++ b/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
@@ -22,6 +22,7 @@ class DrawCommandBuilder {
   final List<DrawCommand> _commands = <DrawCommand>[];
   final Map<Object, int> _patterns = <Object, int>{};
   final Map<PatternData, int> _patternData = <PatternData, int>{};
+  final Map<TextPosition, int> _textPositions = <TextPosition, int>{};
 
   int _getOrGenerateId<T>(T object, Map<T, int> map) =>
       map.putIfAbsent(object, () => map.length);
@@ -80,6 +81,15 @@ class DrawCommandBuilder {
       DrawCommandType.pattern,
       objectId: patternId,
       patternDataId: patternDataId,
+    ));
+  }
+
+  /// Updates the current text position to [position].
+  void updateTextPosition(TextPosition position) {
+    final int positionId = _getOrGenerateId(position, _textPositions);
+    _commands.add(DrawCommand(
+      DrawCommandType.textPosition,
+      objectId: positionId,
     ));
   }
 
@@ -148,6 +158,7 @@ class DrawCommandBuilder {
       drawImages: _drawImages.keys.toList(),
       commands: _commands,
       patternData: _patternData.keys.toList(),
+      textPositions: _textPositions.keys.toList(),
     );
   }
 }

--- a/packages/vector_graphics_compiler/lib/src/paint.dart
+++ b/packages/vector_graphics_compiler/lib/src/paint.dart
@@ -1291,6 +1291,29 @@ class TextPosition {
         other.reset == reset &&
         other.transform == transform;
   }
+
+  @override
+  String toString() {
+    final StringBuffer buffer = StringBuffer();
+    buffer.write('TextPosition(reset: $reset');
+    if (x != null) {
+      buffer.write(', x: $x');
+    }
+    if (y != null) {
+      buffer.write(', y: $y');
+    }
+    if (dx != null) {
+      buffer.write(', dx: $dx');
+    }
+    if (dy != null) {
+      buffer.write(', dy: $dy');
+    }
+    if (transform != null) {
+      buffer.write(', transform: $transform');
+    }
+    buffer.write(')');
+    return buffer.toString();
+  }
 }
 
 /// Additional text specific configuration that is added to the encoding.

--- a/packages/vector_graphics_compiler/lib/src/paint.dart
+++ b/packages/vector_graphics_compiler/lib/src/paint.dart
@@ -1230,12 +1230,74 @@ enum TileMode {
   decal,
 }
 
+/// A description of how to update the current text position.
+///
+/// If [reset] is true, this update discards the previous current text position.
+/// Otherwise, it appends to the previous text position.
+@immutable
+class TextPosition {
+  /// See [TextPosition].
+  const TextPosition({
+    this.x,
+    this.y,
+    this.dx,
+    this.dy,
+    this.reset = false,
+    this.transform,
+  });
+
+  /// The horizontal axis coordinate for the current text position.
+  ///
+  /// If null, use the current text position accumulated since the last [reset],
+  /// or 0 if this represents a reset.
+  final double? x;
+
+  /// The horizontal axis coordinate to add to the current text position.
+  ///
+  /// If null, use the current text position accumulated since the last [reset],
+  /// or 0 if this represents a reset.
+  final double? dx;
+
+  /// The vertical axis coordinate for the current text position.
+  ///
+  /// If null, use the current text position accumulated since the last [reset],
+  /// or 0 if this represents a reset.
+  final double? y;
+
+  /// The vertical axis coordinate to add to the current text position.
+  ///
+  /// If null, use the current text position accumulated since the last [reset],
+  /// or 0 if this represents a reset.
+  final double? dy;
+
+  /// If true, reset the current text position using [x] and [y].
+  final bool reset;
+
+  /// A transform applied to the rendered font.
+  ///
+  /// If `null` this implies no transform.
+  final AffineMatrix? transform;
+
+  @override
+  int get hashCode => Object.hash(x, y, dx, dy, reset, transform);
+
+  @override
+  bool operator ==(Object other) {
+    return other is TextPosition &&
+        other.x == x &&
+        other.y == y &&
+        other.dx == dx &&
+        other.dy == dy &&
+        other.reset == reset &&
+        other.transform == transform;
+  }
+}
+
 /// Additional text specific configuration that is added to the encoding.
 class TextConfig {
   /// Create a new [TextStyle] object.
   const TextConfig(
     this.text,
-    this.baselineStart,
     this.xAnchorMultiplier,
     this.fontFamily,
     this.fontWeight,
@@ -1243,19 +1305,15 @@ class TextConfig {
     this.decoration,
     this.decorationStyle,
     this.decorationColor,
-    this.transform,
   );
 
   /// The text to be rendered.
   final String text;
 
-  /// The coordinate of the starting point of the text baseline.
-  final Point baselineStart;
-
   /// A multiplier for text anchoring.
   ///
   /// This value should be multiplied by the length of the longest line in the
-  /// text and subtracted from [baselineStart]'s x coordinate.
+  /// text and subtracted from x coordinate of the current [TextPosition].
   final double xAnchorMultiplier;
 
   /// The size of the font, only supported as absolute size.
@@ -1276,15 +1334,9 @@ class TextConfig {
   /// The color to use for the decoration, if any.
   final Color decorationColor;
 
-  /// A transform applied to the rendered font.
-  ///
-  /// If `null` this implies no transform.
-  final AffineMatrix? transform;
-
   @override
   int get hashCode => Object.hash(
         text,
-        baselineStart,
         xAnchorMultiplier,
         fontSize,
         fontFamily,
@@ -1292,37 +1344,32 @@ class TextConfig {
         decoration,
         decorationStyle,
         decorationColor,
-        transform,
       );
 
   @override
   bool operator ==(Object other) {
     return other is TextConfig &&
         other.text == text &&
-        other.baselineStart == baselineStart &&
         other.xAnchorMultiplier == xAnchorMultiplier &&
         other.fontSize == fontSize &&
         other.fontFamily == fontFamily &&
         other.fontWeight == fontWeight &&
         other.decoration == decoration &&
         other.decorationStyle == decorationStyle &&
-        other.decorationColor == decorationColor &&
-        other.transform == transform;
+        other.decorationColor == decorationColor;
   }
 
   @override
   String toString() {
     return 'TextConfig('
         "'$text', "
-        '$baselineStart, '
         '$xAnchorMultiplier, '
         "'$fontFamily', "
         '$fontWeight, '
         '$fontSize, '
         '$decoration, '
         '$decorationStyle, '
-        '$decorationColor, '
-        '$transform,)';
+        '$decorationColor,)';
   }
 }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/_tessellator_ffi.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_tessellator_ffi.dart
@@ -68,6 +68,17 @@ class Tessellator extends Visitor<Node, void>
   }
 
   @override
+  Node visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    return ResolvedTextPositionNode(
+      textPositionNode.textPosition,
+      <Node>[
+        for (Node child in textPositionNode.children) child.accept(this, data)
+      ],
+    );
+  }
+
+  @override
   Node visitResolvedPath(ResolvedPathNode pathNode, void data) {
     final Fill? fill = pathNode.paint.fill;
     final Stroke? stroke = pathNode.paint.stroke;

--- a/packages/vector_graphics_compiler/lib/src/svg/_tessellator_unsupported.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/_tessellator_unsupported.dart
@@ -75,4 +75,10 @@ class Tessellator extends Visitor<Node, void>
   Node visitResolvedPatternNode(ResolvedPatternNode patternNode, void data) {
     return patternNode;
   }
+
+  @override
+  Node visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    return textPositionNode;
+  }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/clipping_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/clipping_optimizer.dart
@@ -237,4 +237,18 @@ class ClippingOptimizer extends Visitor<_Result, Node>
   _Result visitResolvedPatternNode(ResolvedPatternNode patternNode, Node data) {
     return _Result(patternNode);
   }
+
+  @override
+  _Result visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    return _Result(
+      ResolvedTextPositionNode(
+        textPositionNode.textPosition,
+        <Node>[
+          for (Node child in textPositionNode.children)
+            child.accept(this, data).node
+        ],
+      ),
+    );
+  }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
@@ -344,4 +344,18 @@ class MaskingOptimizer extends Visitor<_Result, Node>
   _Result visitResolvedPatternNode(ResolvedPatternNode patternNode, Node data) {
     return _Result(patternNode);
   }
+
+  @override
+  _Result visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    return _Result(
+      ResolvedTextPositionNode(
+        textPositionNode.textPosition,
+        <Node>[
+          for (Node child in textPositionNode.children)
+            child.accept(this, data).node
+        ],
+      ),
+    );
+  }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
@@ -21,22 +21,18 @@ class _Result {
 /// Converts a vector_graphics PathFillType to a path_ops FillType.
 path_ops.FillType toPathOpsFillTyle(PathFillType fill) {
   switch (fill) {
-    case PathFillType.evenOdd:
-      return path_ops.FillType.evenOdd;
+    case PathFillType.evenOdd: return path_ops.FillType.evenOdd;
 
-    case PathFillType.nonZero:
-      return path_ops.FillType.nonZero;
+    case PathFillType.nonZero: return path_ops.FillType.nonZero;
   }
 }
 
 /// Converts a path_ops FillType to a vector_graphics PathFillType
 PathFillType toVectorGraphicsFillType(path_ops.FillType fill) {
   switch (fill) {
-    case path_ops.FillType.evenOdd:
-      return PathFillType.evenOdd;
+    case path_ops.FillType.evenOdd: return PathFillType.evenOdd;
 
-    case path_ops.FillType.nonZero:
-      return PathFillType.nonZero;
+    case path_ops.FillType.nonZero: return PathFillType.nonZero;
   }
 }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/masking_optimizer.dart
@@ -21,18 +21,22 @@ class _Result {
 /// Converts a vector_graphics PathFillType to a path_ops FillType.
 path_ops.FillType toPathOpsFillTyle(PathFillType fill) {
   switch (fill) {
-    case PathFillType.evenOdd: return path_ops.FillType.evenOdd;
+    case PathFillType.evenOdd:
+      return path_ops.FillType.evenOdd;
 
-    case PathFillType.nonZero: return path_ops.FillType.nonZero;
+    case PathFillType.nonZero:
+      return path_ops.FillType.nonZero;
   }
 }
 
 /// Converts a path_ops FillType to a vector_graphics PathFillType
 PathFillType toVectorGraphicsFillType(path_ops.FillType fill) {
   switch (fill) {
-    case path_ops.FillType.evenOdd: return PathFillType.evenOdd;
+    case path_ops.FillType.evenOdd:
+      return PathFillType.evenOdd;
 
-    case path_ops.FillType.nonZero: return PathFillType.nonZero;
+    case path_ops.FillType.nonZero:
+      return PathFillType.nonZero;
   }
 }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/overdraw_optimizer.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/overdraw_optimizer.dart
@@ -334,4 +334,18 @@ class OverdrawOptimizer extends Visitor<_Result, Node>
   _Result visitResolvedPatternNode(ResolvedPatternNode patternNode, Node data) {
     return _Result(patternNode);
   }
+
+  @override
+  _Result visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    return _Result(
+      ResolvedTextPositionNode(
+        textPositionNode.textPosition,
+        <Node>[
+          for (Node child in textPositionNode.children)
+            child.accept(this, data).node
+        ],
+      ),
+    );
+  }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -449,6 +449,8 @@ class _Elements {
       parserState._currentAttributes
     ];
 
+    final ParentNode group = ParentNode(parserState._currentAttributes);
+
     SvgAttributes computeCurrentAttributes() {
       final SvgAttributes current = currentAttributes.last;
       final SvgAttributes newAttributes = parserState._currentAttributes
@@ -468,7 +470,7 @@ class _Elements {
           !isPercentage(rawX); // TODO: do we need to handle mixed case.
       final double x = parseDecimalOrPercentage(rawX);
       final double y = parseDecimalOrPercentage(rawY);
-      parserState.currentGroup!.addChild(
+      group.addChild(
         TextNode(
           text,
           Point(x, y),
@@ -494,6 +496,12 @@ class _Elements {
         currentAttributes.removeLast();
       }
     }
+    parserState.currentGroup!.addChild(
+      group,
+      clipResolver: parserState._definitions.getClipPath,
+      maskResolver: parserState._definitions.getDrawable,
+      patternResolver: parserState._definitions.getDrawable,
+    );
   }
 }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -981,14 +981,10 @@ class SvgParser {
       return null;
     }
     switch (textDecoration) {
-      case 'none':
-        return TextDecoration.none;
-      case 'underline':
-        return TextDecoration.underline;
-      case 'overline':
-        return TextDecoration.overline;
-      case 'line-through':
-        return TextDecoration.lineThrough;
+      case 'none': return TextDecoration.none;
+      case 'underline': return TextDecoration.underline;
+      case 'overline': return TextDecoration.overline;
+      case 'line-through': return TextDecoration.lineThrough;
     }
     throw UnsupportedError(
         'Attribute value for text-decoration="$textDecoration"'
@@ -1001,16 +997,11 @@ class SvgParser {
       return null;
     }
     switch (textDecorationStyle) {
-      case 'solid':
-        return TextDecorationStyle.solid;
-      case 'dashed':
-        return TextDecorationStyle.dashed;
-      case 'dotted':
-        return TextDecorationStyle.dotted;
-      case 'double':
-        return TextDecorationStyle.double;
-      case 'wavy':
-        return TextDecorationStyle.wavy;
+      case 'solid': return TextDecorationStyle.solid;
+      case 'dashed': return TextDecorationStyle.dashed;
+      case 'dotted': return TextDecorationStyle.dotted;
+      case 'double': return TextDecorationStyle.double;
+      case 'wavy': return TextDecorationStyle.wavy;
     }
     throw UnsupportedError(
         'Attribute value for text-decoration-style="$textDecorationStyle"'
@@ -1020,15 +1011,11 @@ class SvgParser {
   /// Parses a `text-anchor` attribute.
   double? parseTextAnchor(String? raw) {
     switch (raw) {
-      case 'end':
-        return 1;
-      case 'middle':
-        return .5;
-      case 'start':
-        return 0;
+      case 'end': return 1;
+      case 'middle': return .5;
+      case 'start': return 0;
       case 'inherit':
-      default:
-        return null;
+      default: return null;
     }
   }
 
@@ -1107,12 +1094,9 @@ class SvgParser {
   TileMode? parseTileMode() {
     final String? spreadMethod = attribute('spreadMethod');
     switch (spreadMethod) {
-      case 'pad':
-        return TileMode.clamp;
-      case 'repeat':
-        return TileMode.repeated;
-      case 'reflect':
-        return TileMode.mirror;
+      case 'pad': return TileMode.clamp;
+      case 'repeat': return TileMode.repeated;
+      case 'reflect': return TileMode.mirror;
     }
     return null;
   }
@@ -1121,10 +1105,8 @@ class SvgParser {
   GradientUnitMode? parseGradientUnitMode() {
     final String? gradientUnits = attribute('gradientUnits');
     switch (gradientUnits) {
-      case 'userSpaceOnUse':
-        return GradientUnitMode.userSpaceOnUse;
-      case 'objectBoundingBox':
-        return GradientUnitMode.objectBoundingBox;
+      case 'userSpaceOnUse': return GradientUnitMode.userSpaceOnUse;
+      case 'objectBoundingBox': return GradientUnitMode.objectBoundingBox;
     }
     return null;
   }
@@ -1134,14 +1116,10 @@ class SvgParser {
     Stroke? definitionPaint,
   ) {
     switch (raw) {
-      case 'butt':
-        return StrokeCap.butt;
-      case 'round':
-        return StrokeCap.round;
-      case 'square':
-        return StrokeCap.square;
-      default:
-        return definitionPaint?.cap;
+      case 'butt': return StrokeCap.butt;
+      case 'round': return StrokeCap.round;
+      case 'square': return StrokeCap.square;
+      default: return definitionPaint?.cap;
     }
   }
 
@@ -1150,14 +1128,10 @@ class SvgParser {
     Stroke? definitionPaint,
   ) {
     switch (raw) {
-      case 'miter':
-        return StrokeJoin.miter;
-      case 'bevel':
-        return StrokeJoin.bevel;
-      case 'round':
-        return StrokeJoin.round;
-      default:
-        return definitionPaint?.join;
+      case 'miter': return StrokeJoin.miter;
+      case 'bevel': return StrokeJoin.bevel;
+      case 'round': return StrokeJoin.round;
+      default: return definitionPaint?.join;
     }
   }
 
@@ -1253,28 +1227,17 @@ class SvgParser {
     }
 
     switch (fontWeight) {
-      case 'normal':
-        return normalFontWeight;
-      case 'bold':
-        return boldFontWeight;
-      case '100':
-        return FontWeight.w100;
-      case '200':
-        return FontWeight.w200;
-      case '300':
-        return FontWeight.w300;
-      case '400':
-        return FontWeight.w400;
-      case '500':
-        return FontWeight.w500;
-      case '600':
-        return FontWeight.w600;
-      case '700':
-        return FontWeight.w700;
-      case '800':
-        return FontWeight.w800;
-      case '900':
-        return FontWeight.w900;
+      case 'normal': return normalFontWeight;
+      case 'bold': return boldFontWeight;
+      case '100': return FontWeight.w100;
+      case '200': return FontWeight.w200;
+      case '300': return FontWeight.w300;
+      case '400': return FontWeight.w400;
+      case '500': return FontWeight.w500;
+      case '600': return FontWeight.w600;
+      case '700': return FontWeight.w700;
+      case '800': return FontWeight.w800;
+      case '900': return FontWeight.w900;
     }
 
     throw StateError('Invalid "font-weight": $fontWeight');

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -999,10 +999,14 @@ class SvgParser {
       return null;
     }
     switch (textDecoration) {
-      case 'none': return TextDecoration.none;
-      case 'underline': return TextDecoration.underline;
-      case 'overline': return TextDecoration.overline;
-      case 'line-through': return TextDecoration.lineThrough;
+      case 'none':
+        return TextDecoration.none;
+      case 'underline':
+        return TextDecoration.underline;
+      case 'overline':
+        return TextDecoration.overline;
+      case 'line-through':
+        return TextDecoration.lineThrough;
     }
     throw UnsupportedError(
         'Attribute value for text-decoration="$textDecoration"'
@@ -1015,11 +1019,16 @@ class SvgParser {
       return null;
     }
     switch (textDecorationStyle) {
-      case 'solid': return TextDecorationStyle.solid;
-      case 'dashed': return TextDecorationStyle.dashed;
-      case 'dotted': return TextDecorationStyle.dotted;
-      case 'double': return TextDecorationStyle.double;
-      case 'wavy': return TextDecorationStyle.wavy;
+      case 'solid':
+        return TextDecorationStyle.solid;
+      case 'dashed':
+        return TextDecorationStyle.dashed;
+      case 'dotted':
+        return TextDecorationStyle.dotted;
+      case 'double':
+        return TextDecorationStyle.double;
+      case 'wavy':
+        return TextDecorationStyle.wavy;
     }
     throw UnsupportedError(
         'Attribute value for text-decoration-style="$textDecorationStyle"'
@@ -1029,11 +1038,15 @@ class SvgParser {
   /// Parses a `text-anchor` attribute.
   double? parseTextAnchor(String? raw) {
     switch (raw) {
-      case 'end': return 1;
-      case 'middle': return .5;
-      case 'start': return 0;
+      case 'end':
+        return 1;
+      case 'middle':
+        return .5;
+      case 'start':
+        return 0;
       case 'inherit':
-      default: return null;
+      default:
+        return null;
     }
   }
 
@@ -1112,9 +1125,12 @@ class SvgParser {
   TileMode? parseTileMode() {
     final String? spreadMethod = attribute('spreadMethod');
     switch (spreadMethod) {
-      case 'pad': return TileMode.clamp;
-      case 'repeat': return TileMode.repeated;
-      case 'reflect': return TileMode.mirror;
+      case 'pad':
+        return TileMode.clamp;
+      case 'repeat':
+        return TileMode.repeated;
+      case 'reflect':
+        return TileMode.mirror;
     }
     return null;
   }
@@ -1123,8 +1139,10 @@ class SvgParser {
   GradientUnitMode? parseGradientUnitMode() {
     final String? gradientUnits = attribute('gradientUnits');
     switch (gradientUnits) {
-      case 'userSpaceOnUse': return GradientUnitMode.userSpaceOnUse;
-      case 'objectBoundingBox': return GradientUnitMode.objectBoundingBox;
+      case 'userSpaceOnUse':
+        return GradientUnitMode.userSpaceOnUse;
+      case 'objectBoundingBox':
+        return GradientUnitMode.objectBoundingBox;
     }
     return null;
   }
@@ -1134,10 +1152,14 @@ class SvgParser {
     Stroke? definitionPaint,
   ) {
     switch (raw) {
-      case 'butt': return StrokeCap.butt;
-      case 'round': return StrokeCap.round;
-      case 'square': return StrokeCap.square;
-      default: return definitionPaint?.cap;
+      case 'butt':
+        return StrokeCap.butt;
+      case 'round':
+        return StrokeCap.round;
+      case 'square':
+        return StrokeCap.square;
+      default:
+        return definitionPaint?.cap;
     }
   }
 
@@ -1146,10 +1168,14 @@ class SvgParser {
     Stroke? definitionPaint,
   ) {
     switch (raw) {
-      case 'miter': return StrokeJoin.miter;
-      case 'bevel': return StrokeJoin.bevel;
-      case 'round': return StrokeJoin.round;
-      default: return definitionPaint?.join;
+      case 'miter':
+        return StrokeJoin.miter;
+      case 'bevel':
+        return StrokeJoin.bevel;
+      case 'round':
+        return StrokeJoin.round;
+      default:
+        return definitionPaint?.join;
     }
   }
 
@@ -1245,17 +1271,28 @@ class SvgParser {
     }
 
     switch (fontWeight) {
-      case 'normal': return normalFontWeight;
-      case 'bold': return boldFontWeight;
-      case '100': return FontWeight.w100;
-      case '200': return FontWeight.w200;
-      case '300': return FontWeight.w300;
-      case '400': return FontWeight.w400;
-      case '500': return FontWeight.w500;
-      case '600': return FontWeight.w600;
-      case '700': return FontWeight.w700;
-      case '800': return FontWeight.w800;
-      case '900': return FontWeight.w900;
+      case 'normal':
+        return normalFontWeight;
+      case 'bold':
+        return boldFontWeight;
+      case '100':
+        return FontWeight.w100;
+      case '200':
+        return FontWeight.w200;
+      case '300':
+        return FontWeight.w300;
+      case '400':
+        return FontWeight.w400;
+      case '500':
+        return FontWeight.w500;
+      case '600':
+        return FontWeight.w600;
+      case '700':
+        return FontWeight.w700;
+      case '800':
+        return FontWeight.w800;
+      case '900':
+        return FontWeight.w900;
     }
 
     throw StateError('Invalid "font-weight": $fontWeight');

--- a/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
@@ -138,7 +138,7 @@ double parsePercentage(String val, {double multiplier = 1.0}) {
 }
 
 /// Whether a string should be treated as a percentage (i.e. if it ends with a `'%'`).
-bool isPercentage(String val) => val.endsWith('%');
+bool isPercentage(String? val) => val?.endsWith('%') ?? false;
 
 /// Parses value from the form '25%', 0.25 or 25.0 as a double.
 /// Note: Percentage or decimals will be multiplied by the total

--- a/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
@@ -23,6 +23,9 @@ abstract class Visitor<S, V> {
   /// Visit a [ClipNode].
   S visitClipNode(ClipNode clipNode, V data);
 
+  /// Visit a [TextPositionNode].
+  S visitTextPositionNode(TextPositionNode textPositionNode, V data);
+
   /// Visit a [TextNode].
   S visitTextNode(TextNode textNode, V data);
 
@@ -43,6 +46,10 @@ abstract class Visitor<S, V> {
 
   /// Visit a [PatternNode].
   S visitPatternNode(PatternNode node, V data);
+
+  /// Visit a [ResolvedTextPositionNode].
+  S visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, V data);
 
   /// Visit a [ResolvedTextNode].
   S visitResolvedText(ResolvedTextNode textNode, V data);
@@ -86,6 +93,11 @@ mixin ErrorOnUnResolvedNode<S, V> on Visitor<S, V> {
 
   @override
   S visitClipNode(ClipNode clipNode, V data) {
+    throw UnsupportedError(_message);
+  }
+
+  @override
+  S visitTextPositionNode(TextPositionNode textPositionNode, V data) {
     throw UnsupportedError(_message);
   }
 
@@ -166,6 +178,15 @@ class CommandBuilderVisitor extends Visitor<void, void>
   @override
   void visitResolvedPath(ResolvedPathNode pathNode, void data) {
     _builder.addPath(pathNode.path, pathNode.paint, null, currentPatternId);
+  }
+
+  @override
+  void visitResolvedTextPositionNode(
+      ResolvedTextPositionNode textPositionNode, void data) {
+    _builder.updateTextPosition(textPositionNode.textPosition);
+    textPositionNode.visitChildren((Node child) {
+      child.accept(this, data);
+    });
   }
 
   @override

--- a/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
+++ b/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
@@ -4,7 +4,7 @@
 
 import 'package:meta/meta.dart';
 import 'geometry/pattern.dart';
-import '../src/geometry/image.dart';
+import 'geometry/image.dart';
 import 'package:vector_graphics_compiler/src/util.dart';
 
 import 'geometry/path.dart';
@@ -28,6 +28,7 @@ class VectorInstructions {
     this.images = const <ImageData>[],
     this.drawImages = const <DrawImageData>[],
     this.patternData = const <PatternData>[],
+    this.textPositions = const <TextPosition>[],
     required this.commands,
   });
 
@@ -58,6 +59,9 @@ class VectorInstructions {
   /// The pattern data objects, if any used in [commands].
   final List<PatternData> patternData;
 
+  /// A list of text position advances, if any, used in [commands].
+  final List<TextPosition> textPositions;
+
   /// The painting order list of drawing commands.
   ///
   /// If the command type is [DrawCommandType.path], this command specifies
@@ -78,7 +82,8 @@ class VectorInstructions {
       Object.hashAll(text),
       Object.hashAll(commands),
       Object.hashAll(images),
-      Object.hashAll(drawImages));
+      Object.hashAll(drawImages),
+      Object.hashAll(textPositions));
 
   @override
   bool operator ==(Object other) {
@@ -92,7 +97,8 @@ class VectorInstructions {
         listEquals(other.text, text) &&
         listEquals(other.commands, commands) &&
         listEquals(other.images, images) &&
-        listEquals(other.drawImages, drawImages);
+        listEquals(other.drawImages, drawImages) &&
+        listEquals(other.textPositions, textPositions);
   }
 
   @override
@@ -140,6 +146,9 @@ enum DrawCommandType {
 
   /// Specifies that this command draws a pattern.
   pattern,
+
+  /// Specifies an adjustment to the current text position.
+  textPosition,
 }
 
 /// A drawing command combining the index of a [Path] or an [IndexedVertices]

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -209,22 +209,20 @@ void main() {
         id: 3,
         shaderId: null,
       ),
-      const OnTextConfig('Plain text Roboto', 100, 0, 50, 55, 'Roboto', 3, 0, 0,
-          4278190080, null, 0),
-      const OnTextConfig('Plain text Verdana', 100, 0, 100, 55, 'Verdana', 3, 0,
-          0, 4278190080, null, 1),
-      const OnTextConfig('Bold text Verdana', 100, 0, 150, 55, 'Verdana', 6, 0,
-          0, 4278190080, null, 2),
-      const OnTextConfig('Stroked bold line', 150, 0, 215, 55, 'Roboto', 8, 0,
-          0, 4278190080, null, 3),
       const OnTextConfig(
-          'Line 3', 150, 0, 50, 55, 'Roboto', 3, 0, 0, 4278190080, null, 4),
-      const OnDrawText(0, 0, null),
-      const OnDrawText(1, 0, null),
-      const OnDrawText(2, 0, null),
-      const OnDrawText(3, 1, null),
-      const OnDrawText(3, 2, null),
-      const OnDrawText(4, 3, null),
+          ' Plain text Roboto', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 0),
+      const OnTextConfig(
+          ' Plain text Verdana', 0, 55, 'Verdana', 3, 0, 0, 4278190080, 1),
+      const OnTextConfig(
+          ' Bold text Verdana', 0, 55, 'Verdana', 6, 0, 0, 4278190080, 2),
+      const OnTextConfig(
+          'Stroked bold line', 0, 55, 'Roboto', 8, 0, 0, 4278190080, 3),
+      const OnTextConfig('Line 3', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 4),
+      const OnDrawText(0, 0, null, null),
+      const OnDrawText(1, 0, null, null),
+      const OnDrawText(2, 0, null, null),
+      const OnDrawText(3, 1, 2, null),
+      const OnDrawText(4, 3, null, null),
     ]);
   });
 
@@ -335,6 +333,17 @@ void main() {
 
 class TestListener extends VectorGraphicsCodecListener {
   final List<Object> commands = <Object>[];
+
+  @override
+  void onTextPosition(int textPositionId, double? x, double? y, double? dx,
+      double? dy, bool reset, Float64List? transform) {
+    // TODO: implement onTextPosition
+  }
+
+  @override
+  void onUpdateTextPosition(int textPositionId) {
+    // TODO: implement onUpdateTextPosition
+  }
 
   @override
   void onDrawPath(int pathId, int? paintId, int? patternId) {
@@ -485,36 +494,30 @@ class TestListener extends VectorGraphicsCodecListener {
   void onTextConfig(
     String text,
     String? fontFamily,
-    double dx,
     double xAnchorMultiplier,
-    double dy,
     int fontWeight,
     double fontSize,
     int decoration,
     int decorationStyle,
     int decorationColor,
-    Float64List? transform,
     int id,
   ) {
     commands.add(OnTextConfig(
       text,
-      dx,
       xAnchorMultiplier,
-      dy,
       fontSize,
       fontFamily,
       fontWeight,
       decoration,
       decorationStyle,
       decorationColor,
-      transform,
       id,
     ));
   }
 
   @override
-  void onDrawText(int textId, int paintId, int? patternId) {
-    commands.add(OnDrawText(textId, paintId, patternId));
+  void onDrawText(int textId, int? fillId, int? strokeId, int? patternId) {
+    commands.add(OnDrawText(textId, fillId, strokeId, patternId));
   }
 
   @override
@@ -906,28 +909,22 @@ class OnSize {
 class OnTextConfig {
   const OnTextConfig(
     this.text,
-    this.x,
     this.xAnchorMultiplier,
-    this.y,
     this.fontSize,
     this.fontFamily,
     this.fontWeight,
     this.decoration,
     this.decorationStyle,
     this.decorationColor,
-    this.transform,
     this.id,
   );
 
   final String text;
-  final double x;
   final double xAnchorMultiplier;
-  final double y;
   final double fontSize;
   final String? fontFamily;
   final int fontWeight;
   final int id;
-  final Float64List? transform;
   final int decoration;
   final int decorationStyle;
   final int decorationColor;
@@ -935,16 +932,13 @@ class OnTextConfig {
   @override
   int get hashCode => Object.hash(
         text,
-        x,
         xAnchorMultiplier,
-        y,
         fontSize,
         fontFamily,
         fontWeight,
         decoration,
         decorationStyle,
         decorationColor,
-        Object.hashAll(transform ?? <double>[]),
         id,
       );
 
@@ -952,42 +946,41 @@ class OnTextConfig {
   bool operator ==(Object other) =>
       other is OnTextConfig &&
       other.text == text &&
-      other.x == x &&
       other.xAnchorMultiplier == xAnchorMultiplier &&
-      other.y == y &&
       other.fontSize == fontSize &&
       other.fontFamily == fontFamily &&
       other.fontWeight == fontWeight &&
       other.decoration == decoration &&
       other.decorationStyle == decorationStyle &&
       other.decorationColor == decorationColor &&
-      _listEquals(other.transform, transform) &&
       other.id == id;
 
   @override
   String toString() =>
-      'OnTextConfig($text, $x (anchor: $xAnchorMultiplier), $y, $fontSize, $fontFamily, $fontWeight, $decoration, $decorationStyle, $decorationColor, $transform, $id)';
+      'OnTextConfig($text, (anchor: $xAnchorMultiplier), $fontSize, $fontFamily, $fontWeight, $decoration, $decorationStyle, $decorationColor, $id)';
 }
 
 class OnDrawText {
-  const OnDrawText(this.textId, this.paintId, this.patternId);
+  const OnDrawText(this.textId, this.fillId, this.strokeId, this.patternId);
 
   final int textId;
-  final int paintId;
+  final int? fillId;
+  final int? strokeId;
   final int? patternId;
 
   @override
-  int get hashCode => Object.hash(textId, paintId, patternId);
+  int get hashCode => Object.hash(textId, fillId, strokeId, patternId);
 
   @override
   bool operator ==(Object other) =>
       other is OnDrawText &&
       other.textId == textId &&
-      other.paintId == paintId &&
+      other.fillId == fillId &&
+      other.strokeId == strokeId &&
       other.patternId == patternId;
 
   @override
-  String toString() => 'OnDrawText($textId, $paintId, $patternId)';
+  String toString() => 'OnDrawText($textId, $fillId, $strokeId, $patternId)';
 }
 
 class OnImage {

--- a/packages/vector_graphics_compiler/test/end_to_end_test.dart
+++ b/packages/vector_graphics_compiler/test/end_to_end_test.dart
@@ -210,14 +210,14 @@ void main() {
         shaderId: null,
       ),
       const OnTextConfig(
-          ' Plain text Roboto', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 0),
+          'Plain text Roboto', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 0),
       const OnTextConfig(
-          ' Plain text Verdana', 0, 55, 'Verdana', 3, 0, 0, 4278190080, 1),
+          'Plain text Verdana', 0, 55, 'Verdana', 3, 0, 0, 4278190080, 1),
       const OnTextConfig(
-          ' Bold text Verdana', 0, 55, 'Verdana', 6, 0, 0, 4278190080, 2),
+          'Bold text Verdana', 0, 55, 'Verdana', 6, 0, 0, 4278190080, 2),
       const OnTextConfig(
-          'Stroked bold line', 0, 55, 'Roboto', 8, 0, 0, 4278190080, 3),
-      const OnTextConfig('Line 3', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 4),
+          ' Stroked bold line', 0, 55, 'Roboto', 8, 0, 0, 4278190080, 3),
+      const OnTextConfig(' Line 3', 0, 55, 'Roboto', 3, 0, 0, 4278190080, 4),
       const OnDrawText(0, 0, null, null),
       const OnDrawText(1, 0, null, null),
       const OnDrawText(2, 0, null, null),

--- a/packages/vector_graphics_compiler/test/node_test.dart
+++ b/packages/vector_graphics_compiler/test/node_test.dart
@@ -11,10 +11,6 @@ void main() {
   test('TextNode returns null for Paint if stroke and fill are missing', () {
     final TextNode node = TextNode(
       'text',
-      Point.zero,
-      true,
-      1,
-      FontWeight.w500,
       SvgAttributes.empty,
     );
     expect(node.computePaint(Rect.largest, AffineMatrix.identity), null);

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,22 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('stroke-opacity is kept', () {
+    const String strokeOpacitySvg = '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="5" height="5" stroke="red" stroke-opacity=".5" />
+</svg>
+''';
+
+    final VectorInstructions instructions =
+        parseWithoutOptimizers(strokeOpacitySvg);
+
+    expect(
+      instructions.paints.single,
+      const Paint(stroke: Stroke(color: Color(0x7fff0000))),
+    );
+  });
+
   test('text attributes are preserved', () {
     final VectorInstructions instructions = parseWithoutOptimizers(textTspan);
     expect(
@@ -19,7 +35,7 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          AffineMatrix.identity,
+          null,
         ),
         TextConfig(
           'more text.',
@@ -31,7 +47,7 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          AffineMatrix.identity,
+          null,
         ),
         TextConfig(
           'Even more text',
@@ -43,7 +59,7 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          AffineMatrix.identity,
+          null,
         ),
         TextConfig(
           'text everywhere',
@@ -55,7 +71,7 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          AffineMatrix.identity,
+          null,
         ),
         TextConfig(
           'so many lines',
@@ -67,7 +83,7 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          AffineMatrix.identity,
+          null,
         ),
       ],
     );
@@ -335,7 +351,7 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        AffineMatrix.identity,
+        null,
       ),
       TextConfig(
         'Text anchor middle',
@@ -347,7 +363,7 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        AffineMatrix.identity,
+        null,
       ),
       TextConfig(
         'Text anchor end',
@@ -359,7 +375,7 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        AffineMatrix.identity,
+        null,
       )
     ]);
   });
@@ -380,7 +396,7 @@ void main() {
         TextDecoration.overline,
         TextDecorationStyle.solid,
         Color(0xffff0000),
-        AffineMatrix.identity,
+        null,
       ),
       TextConfig(
         'Strike text',
@@ -392,7 +408,7 @@ void main() {
         TextDecoration.lineThrough,
         TextDecorationStyle.solid,
         Color(0xff008000),
-        AffineMatrix.identity,
+        null,
       ),
       TextConfig(
         'Underline text',
@@ -404,7 +420,7 @@ void main() {
         TextDecoration.underline,
         TextDecorationStyle.double,
         Color(0xff008000),
-        AffineMatrix.identity,
+        null,
       )
     ]);
   });
@@ -1094,7 +1110,7 @@ void main() {
   });
 
   test('Parses text with pattern as fill', () {
-    const String textWithPattern = ''' <svg width="600" height="400">
+    const String textWithPattern = '''<svg width="600" height="400">
     <defs>
           <pattern id="textPattern" x="7" y="7" width="10" height="10" patternUnits="userSpaceOnUse">
                   <rect x="5" y="5" width="5" height="5" fill= "#876fc1" />
@@ -1114,6 +1130,8 @@ void main() {
       DrawCommand(DrawCommandType.restore),
       DrawCommand(DrawCommandType.text, objectId: 0, paintId: 1, patternId: 0)
     ]);
+
+    expect(instructions.text, const <TextConfig>[]);
   });
 
   test('Defaults image height/width when not specified', () {

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -26,8 +26,7 @@ void main() {
       instructions.text,
       const <TextConfig>[
         TextConfig(
-          'Some text',
-          Point(33.0, 53.0),
+          'Some text ',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -35,11 +34,9 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          null,
         ),
         TextConfig(
           'more text.',
-          Point(33.0, 73.0),
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -47,11 +44,9 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          null,
         ),
         TextConfig(
-          'Even more text',
-          Point(35.0, 352.0),
+          'Even more text ',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -59,11 +54,9 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          null,
         ),
         TextConfig(
-          'text everywhere',
-          Point(35.0, 372.0),
+          'text everywhere ',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -71,11 +64,9 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          null,
         ),
         TextConfig(
           'so many lines',
-          Point(35.0, 392.0),
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -83,7 +74,6 @@ void main() {
           TextDecoration.none,
           TextDecorationStyle.solid,
           Color(0xff000000),
-          null,
         ),
       ],
     );
@@ -342,8 +332,7 @@ void main() {
 
     expect(instructions.text, const <TextConfig>[
       TextConfig(
-        'Text anchor start',
-        Point(100.0, 50.0),
+        ' Text anchor start',
         0.0,
         'Roboto',
         FontWeight.w400,
@@ -351,11 +340,9 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        null,
       ),
       TextConfig(
-        'Text anchor middle',
-        Point(100.0, 100.0),
+        ' Text anchor middle',
         0.5,
         'Roboto',
         FontWeight.w400,
@@ -363,11 +350,9 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        null,
       ),
       TextConfig(
-        'Text anchor end',
-        Point(100.0, 150.0),
+        ' Text anchor end',
         1.0,
         'Roboto',
         FontWeight.w400,
@@ -375,7 +360,6 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color(0xff000000),
-        null,
       )
     ]);
   });
@@ -387,8 +371,7 @@ void main() {
 
     expect(instructions.text, const <TextConfig>[
       TextConfig(
-        'Overline text',
-        Point(100.0, 60.0),
+        ' Overline text',
         0,
         'Roboto',
         FontWeight.w400,
@@ -396,11 +379,9 @@ void main() {
         TextDecoration.overline,
         TextDecorationStyle.solid,
         Color(0xffff0000),
-        null,
       ),
       TextConfig(
-        'Strike text',
-        Point(100.0, 120.0),
+        ' Strike text',
         0,
         'Roboto',
         FontWeight.w400,
@@ -408,11 +389,9 @@ void main() {
         TextDecoration.lineThrough,
         TextDecorationStyle.solid,
         Color(0xff008000),
-        null,
       ),
       TextConfig(
-        'Underline text',
-        Point(100.0, 180.0),
+        ' Underline text',
         0,
         'Roboto',
         FontWeight.w400,
@@ -420,7 +399,6 @@ void main() {
         TextDecoration.underline,
         TextDecorationStyle.double,
         Color(0xff008000),
-        null,
       )
     ]);
   });
@@ -546,9 +524,8 @@ void main() {
     expect(instructions.paints.single, const Paint(fill: Fill()));
     expect(
       instructions.text.single,
-      TextConfig(
+      const TextConfig(
         'a',
-        Point.zero,
         0,
         null,
         normalFontWeight,
@@ -556,10 +533,10 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color.opaqueBlack,
-        AffineMatrix.identity
-            .translated(-100, 50)
-            .rotated(radians(10))
-            .translated(100, -50),
+        // AffineMatrix.identity
+        //     .translated(-100, 50)
+        //     .rotated(radians(10))
+        //     .translated(100, -50),
       ),
     );
   });
@@ -1128,10 +1105,25 @@ void main() {
       DrawCommand(DrawCommandType.pattern, objectId: 0),
       DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
       DrawCommand(DrawCommandType.restore),
+      DrawCommand(DrawCommandType.textPosition, objectId: 0),
       DrawCommand(DrawCommandType.text, objectId: 0, paintId: 1, patternId: 0)
     ]);
 
-    expect(instructions.text, const <TextConfig>[]);
+    expect(
+      instructions.text,
+      const <TextConfig>[
+        TextConfig(
+          'Text',
+          0.0,
+          null,
+          FontWeight.w400,
+          200.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+        )
+      ],
+    );
   });
 
   test('Defaults image height/width when not specified', () {

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,75 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('text attributes are preserved', () {
+    final VectorInstructions instructions = parseWithoutOptimizers(textTspan);
+    expect(
+      instructions.text,
+      const <TextConfig>[
+        TextConfig(
+          'Some text',
+          Point(33.0, 53.0),
+          0.0,
+          'Roboto-Regular, Roboto',
+          FontWeight.w400,
+          16.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+          AffineMatrix.identity,
+        ),
+        TextConfig(
+          'more text.',
+          Point(33.0, 73.0),
+          0.0,
+          'Roboto-Regular, Roboto',
+          FontWeight.w400,
+          16.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+          AffineMatrix.identity,
+        ),
+        TextConfig(
+          'Even more text',
+          Point(35.0, 352.0),
+          0.0,
+          'Roboto-Regular, Roboto',
+          FontWeight.w400,
+          16.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+          AffineMatrix.identity,
+        ),
+        TextConfig(
+          'text everywhere',
+          Point(35.0, 372.0),
+          0.0,
+          'Roboto-Regular, Roboto',
+          FontWeight.w400,
+          16.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+          AffineMatrix.identity,
+        ),
+        TextConfig(
+          'so many lines',
+          Point(35.0, 392.0),
+          0.0,
+          'Roboto-Regular, Roboto',
+          FontWeight.w400,
+          16.0,
+          TextDecoration.none,
+          TextDecorationStyle.solid,
+          Color(0xff000000),
+          AffineMatrix.identity,
+        ),
+      ],
+    );
+  });
+
   test('currentColor', () {
     const String currentColorSvg = '''
 <svg viewBox="0 0 10 10">

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,60 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('text spacing', () {
+    const String svg = '''
+<svg width="185" height="43" viewBox="0 0 185 43" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <text x="35.081" y="15" font-family="OpenSans-Italic, Open Sans" font-size="14" font-style="italic" fill="#333">
+            π( D² - d² )( N - N
+            <tspan y="15" font-size="10">u</tspan>
+            )
+        </text>
+    </g>
+</svg>
+''';
+
+    final VectorInstructions instructions = parseWithoutOptimizers(svg);
+
+    expect(instructions.textPositions, const <TextPosition>[
+      TextPosition(reset: true, x: 35.081, y: 15.0),
+      TextPosition(y: 15.0),
+    ]);
+
+    expect(instructions.text, const <TextConfig>[
+      TextConfig(
+        'π( D² - d² )( N - N',
+        0.0,
+        'OpenSans-Italic, Open Sans',
+        FontWeight.w400,
+        14.0,
+        TextDecoration.none,
+        TextDecorationStyle.solid,
+        Color(0xff000000),
+      ),
+      TextConfig(
+        ' u',
+        0.0,
+        'OpenSans-Italic, Open Sans',
+        FontWeight.w400,
+        10.0,
+        TextDecoration.none,
+        TextDecorationStyle.solid,
+        Color(0xff000000),
+      ),
+      TextConfig(
+        ' )',
+        0.0,
+        'OpenSans-Italic, Open Sans',
+        FontWeight.w400,
+        14.0,
+        TextDecoration.none,
+        TextDecorationStyle.solid,
+        Color(0xff000000),
+      ),
+    ]);
+  });
+
   test('stroke-opacity', () {
     const String strokeOpacitySvg = '''
 <svg viewBox="0 0 10 10">
@@ -26,7 +80,7 @@ void main() {
       instructions.text,
       const <TextConfig>[
         TextConfig(
-          'Some text ',
+          ' Some text',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -36,7 +90,7 @@ void main() {
           Color(0xff000000),
         ),
         TextConfig(
-          'more text.',
+          ' more text.',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -46,7 +100,7 @@ void main() {
           Color(0xff000000),
         ),
         TextConfig(
-          'Even more text ',
+          ' Even more text',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -56,7 +110,7 @@ void main() {
           Color(0xff000000),
         ),
         TextConfig(
-          'text everywhere ',
+          ' text everywhere',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -66,7 +120,7 @@ void main() {
           Color(0xff000000),
         ),
         TextConfig(
-          'so many lines',
+          ' so many lines',
           0.0,
           'Roboto-Regular, Roboto',
           FontWeight.w400,
@@ -332,7 +386,7 @@ void main() {
 
     expect(instructions.text, const <TextConfig>[
       TextConfig(
-        ' Text anchor start',
+        'Text anchor start',
         0.0,
         'Roboto',
         FontWeight.w400,
@@ -342,7 +396,7 @@ void main() {
         Color(0xff000000),
       ),
       TextConfig(
-        ' Text anchor middle',
+        'Text anchor middle',
         0.5,
         'Roboto',
         FontWeight.w400,
@@ -352,7 +406,7 @@ void main() {
         Color(0xff000000),
       ),
       TextConfig(
-        ' Text anchor end',
+        'Text anchor end',
         1.0,
         'Roboto',
         FontWeight.w400,
@@ -371,7 +425,7 @@ void main() {
 
     expect(instructions.text, const <TextConfig>[
       TextConfig(
-        ' Overline text',
+        'Overline text',
         0,
         'Roboto',
         FontWeight.w400,
@@ -381,7 +435,7 @@ void main() {
         Color(0xffff0000),
       ),
       TextConfig(
-        ' Strike text',
+        'Strike text',
         0,
         'Roboto',
         FontWeight.w400,
@@ -391,7 +445,7 @@ void main() {
         Color(0xff008000),
       ),
       TextConfig(
-        ' Underline text',
+        'Underline text',
         0,
         'Roboto',
         FontWeight.w400,

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -577,6 +577,16 @@ void main() {
     );
     expect(instructions.paints.single, const Paint(fill: Fill()));
     expect(
+      instructions.textPositions.single,
+      TextPosition(
+        reset: true,
+        transform: AffineMatrix.identity
+            .translated(-100, 50)
+            .rotated(radians(10))
+            .translated(100, -50),
+      ),
+    );
+    expect(
       instructions.text.single,
       const TextConfig(
         'a',
@@ -587,10 +597,6 @@ void main() {
         TextDecoration.none,
         TextDecorationStyle.solid,
         Color.opaqueBlack,
-        // AffineMatrix.identity
-        //     .translated(-100, 50)
-        //     .rotated(radians(10))
-        //     .translated(100, -50),
       ),
     );
   });

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -1423,9 +1423,17 @@ const String signWithScaledStroke = '''
 const String textTspan = '''
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
   <g>
-    <g>
-      <text transform="translate(33 38)" fill="rgba(0,0,0,0.6)" font-size="16" font-family="Roboto-Regular, Roboto" letter-spacing="0.009em"><tspan x="0" y="15">Some text </tspan><tspan x="0" y="35">more text.</tspan></text>
-      <text transform="translate(35 337)" fill="rgba(0,0,0,0.6)" font-size="16" font-family="Roboto-Regular, Roboto" letter-spacing="0.009em"><tspan x="0" y="15">Even more text </tspan><tspan x="0" y="35">text everywhere </tspan><tspan x="0" y="55">so many lines</tspan></text>
+    <text transform="translate(33 38)" fill="rgba(0,0,0,0.6)" font-size="16"
+      font-family="Roboto-Regular, Roboto" letter-spacing="0.009em">
+      <tspan x="0" y="15">Some text </tspan>
+      <tspan x="0" y="35">more text.</tspan>
+    </text>
+    <text transform="translate(35 337)" fill="rgba(0,0,0,0.6)" font-size="16"
+      font-family="Roboto-Regular, Roboto" letter-spacing="0.009em">
+      <tspan x="0" y="15">Even more text </tspan>
+      <tspan x="0" y="35">text everywhere </tspan>
+      <tspan x="0" y="55">so many lines</tspan>
+    </text>
   </g>
 </svg>
 ''';

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -1419,3 +1419,13 @@ const String signWithScaledStroke = '''
  </g>
 </svg>
 ''';
+
+const String textTspan = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <g>
+    <g>
+      <text transform="translate(33 38)" fill="rgba(0,0,0,0.6)" font-size="16" font-family="Roboto-Regular, Roboto" letter-spacing="0.009em"><tspan x="0" y="15">Some text </tspan><tspan x="0" y="35">more text.</tspan></text>
+      <text transform="translate(35 337)" fill="rgba(0,0,0,0.6)" font-size="16" font-family="Roboto-Regular, Roboto" letter-spacing="0.009em"><tspan x="0" y="15">Even more text </tspan><tspan x="0" y="35">text everywhere </tspan><tspan x="0" y="55">so many lines</tspan></text>
+  </g>
+</svg>
+''';


### PR DESCRIPTION
We're currently ignoring the attributes on `<text>` when there's nested `tspan`s. 

Fixes https://github.com/dnfield/flutter_svg/issues/870 with a reduced test case.
Fixes https://github.com/dnfield/flutter_svg/issues/872
Fixes https://github.com/dnfield/flutter_svg/issues/763
Fixes https://github.com/dnfield/flutter_svg/issues/762 (which is probably a duplicate of 763).
