### PR TITLE
Preserve stroke-opacity

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -2168,7 +2168,7 @@ class SvgStrokeAttributes {
     }
 
     return Stroke(
-      color: color,
+      color: color!.withOpacity(opacity ?? 1.0),
       shader: shader,
       join: join,
       cap: cap,

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,22 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('stroke-opacity', () {
+    const String strokeOpacitySvg = '''
+<svg viewBox="0 0 10 10">
+  <rect x="0" y="0" width="5" height="5" stroke="red" stroke-opacity=".5" />
+</svg>
+''';
+
+    final VectorInstructions instructions =
+        parseWithoutOptimizers(strokeOpacitySvg);
+
+    expect(
+      instructions.paints.single,
+      const Paint(stroke: Stroke(color: Color(0x7fff0000))),
+    );
+  });
+
   test('currentColor', () {
     const String currentColorSvg = '''
 <svg viewBox="0 0 10 10">


### PR DESCRIPTION
Discovered this look at https://github.com/dnfield/flutter_svg/issues/872 - it's the reason the rectangle in the middle is darker than the rest.