### PR TITLE
Make sure that attributes are inherited down all nodes with children,…

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -321,7 +321,6 @@ class ClipNode extends TransformableNode {
     required this.child,
     required this.clipId,
     required AffineMatrix transform,
-    String? id,
   }) : super(transform);
 
   /// Called by visitors to resolve [clipId] to a list of paths.
@@ -345,6 +344,16 @@ class ClipNode extends TransformableNode {
   @override
   S accept<S, V>(Visitor<S, V> visitor, V data) {
     return visitor.visitClipNode(this, data);
+  }
+
+  @override
+  Node applyAttributes(SvgAttributes newAttributes, {bool replace = false}) {
+    return ClipNode(
+      resolver: resolver,
+      clipId: clipId,
+      transform: transform,
+      child: child.applyAttributes(newAttributes, replace: replace),
+    );
   }
 }
 
@@ -379,6 +388,17 @@ class MaskNode extends TransformableNode {
   @override
   S accept<S, V>(Visitor<S, V> visitor, V data) {
     return visitor.visitMaskNode(this, data);
+  }
+
+  @override
+  Node applyAttributes(SvgAttributes newAttributes, {bool replace = false}) {
+    return MaskNode(
+      resolver: resolver,
+      maskId: maskId,
+      blendMode: blendMode,
+      transform: transform,
+      child: child.applyAttributes(newAttributes, replace: replace),
+    );
   }
 }
 
@@ -606,5 +626,15 @@ class PatternNode extends TransformableNode {
   @override
   S accept<S, V>(Visitor<S, V> visitor, V data) {
     return visitor.visitPatternNode(this, data);
+  }
+
+  @override
+  Node applyAttributes(SvgAttributes newAttributes, {bool replace = false}) {
+    return PatternNode(
+      resolver: resolver,
+      patternId: patternId,
+      transform: transform,
+      child: child.applyAttributes(newAttributes, replace: replace),
+    );
   }
 }

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -57,6 +57,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
     final AffineMatrix nextTransform = parentNode.concatTransform(data);
 
     final Paint? saveLayerPaint = parentNode.createLayerPaint();
+
     final Node result;
     if (saveLayerPaint == null) {
       result = ParentNode(

--- a/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
+++ b/packages/vector_graphics_compiler/test/masking_optimizer_test.dart
@@ -93,9 +93,9 @@ void main() {
 
   test("Don't resolve MaskNode if intersection of Mask and Path is empty", () {
     final Node node = parseAndResolve(
-        '''<svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        '''<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <mask id="a">
-        <path  d="M58.645 16.232L46.953 28.72l2.024 1.895 11.691-12.486"/>
+        <path d="M58.645 16.232L46.953 28.72l2.024 1.895 11.691-12.486"/>
     </mask>
   <path mask="url(#a)" d="M0 0 z"/>
 </svg>

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,37 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('None on fill', () {
+    const String svg = '''
+<svg xmlns="http://www.w3.org/2000/svg" width="384" height="384" fill="none"
+  style="-webkit-print-color-adjust:exact">
+  <defs>
+    <clipPath id="a" class="frame-clip">
+      <rect width="384" height="384" rx="40" ry="40" style="opacity:1" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#a)">
+    <rect width="384" height="384" class="frame-background" rx="40" ry="40" style="opacity:1" />
+    <g class="frame-children">
+      <rect width="290" height="70" x="31" y="32" rx="30" ry="30"
+        style="fill:#22c55e;fill-opacity:1" />
+      <rect width="290" height="70" x="31" y="282" rx="30" ry="30"
+        style="fill:#22c55e;fill-opacity:1" />
+      <rect width="290" height="70" x="95" y="157" rx="30" ry="30"
+        style="fill:#f59e0b;fill-opacity:1" />
+    </g>
+  </g>
+</svg>
+''';
+
+    final VectorInstructions instructions = parseWithoutOptimizers(svg);
+    // Should _not_ contain a paint with an opaque black fill for the rect with class "frame-background".
+    expect(instructions.paints, const <Paint>[
+      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xff22c55e))),
+      Paint(blendMode: BlendMode.srcOver, fill: Fill(color: Color(0xfff59e0b))),
+    ]);
+  });
+
   test('text spacing', () {
     const String svg = '''
 <svg width="185" height="43" viewBox="0 0 185 43" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
… and handle "none" correctly.

This required updating an existing test that had `none` as the fill on the root and thus all children got optimized away (the SVG didn't paint anything at all!) to remove the none there.

Fixes https://github.com/dnfield/flutter_svg/issues/873