### PR TITLE
Fix fill rule inheritence, fix default fill application

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/geometry/path.dart
+++ b/packages/vector_graphics_compiler/lib/src/geometry/path.dart
@@ -333,7 +333,8 @@ class PathBuilder implements PathProxy {
   /// Creates a new path builder for paths of the specified fill type.
   ///
   /// By default, will create non-zero filled paths.
-  PathBuilder([this.fillType = PathFillType.nonZero]);
+  PathBuilder([PathFillType? fillType])
+      : fillType = fillType ?? PathFillType.nonZero;
 
   /// Creates a new mutable path builder object from an existing [Path].
   PathBuilder.fromPath(Path path) {
@@ -518,6 +519,14 @@ class Path {
     _commands.addAll(commands);
   }
 
+  /// Creates a copy of this path, replacing the current [fillType] with [type].
+  Path withFillType(PathFillType type) {
+    if (type == fillType) {
+      return this;
+    }
+    return Path(fillType: type, commands: _commands);
+  }
+
   /// Whether this path has any commands.
   bool get isEmpty => _commands.isEmpty;
 
@@ -641,10 +650,9 @@ class Path {
 }
 
 /// Creates a new [Path] object from an SVG path data string.
-Path parseSvgPathData(String svg, [PathFillType type = PathFillType.nonZero]) {
-  // TODO(dnfield): get rid of PathFillType on paint.
+Path parseSvgPathData(String svg, [PathFillType? type]) {
   if (svg == '') {
-    return Path(fillType: type);
+    return Path(fillType: type ?? PathFillType.nonZero);
   }
 
   final SvgPathStringSource parser = SvgPathStringSource(svg);

--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -420,7 +420,7 @@ class PathNode extends AttributedNode {
     final Fill? fill = attributes.fill?.toFill(
       bounds,
       transform,
-      defaultColor: stroke?.color == null ? Color.opaqueBlack : null,
+      defaultColor: Color.opaqueBlack,
     );
     if (fill == null && stroke == null) {
       return null;

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1661,7 +1661,7 @@ class SvgParser {
           id,
         ),
         fillRule:
-            parseRawFillRule(attributeMap['fill-rule']) ?? PathFillType.nonZero,
+            parseRawFillRule(attributeMap['fill-rule']),
         clipRule: parseRawFillRule(attributeMap['clip-rule']),
         clipPathId: attributeMap['clip-path'],
         blendMode: _blendModes[attributeMap['mix-blend-mode']],
@@ -1832,7 +1832,7 @@ class SvgAttributes {
     this.color = const ColorOrNone.color(),
     this.stroke,
     this.fill,
-    this.fillRule = PathFillType.nonZero,
+    this.fillRule,
     this.clipRule,
     this.clipPathId,
     this.blendMode,
@@ -1954,7 +1954,7 @@ class SvgAttributes {
   final AffineMatrix transform;
 
   /// The `@fill-rule` attribute.
-  final PathFillType fillRule;
+  final PathFillType? fillRule;
 
   /// The `@clip-rule` attribute.
   final PathFillType? clipRule;
@@ -2062,7 +2062,7 @@ class SvgAttributes {
       color: color._applyParent(parent.color),
       stroke: stroke?.applyParent(parent.stroke) ?? parent.stroke,
       fill: fill?.applyParent(parent.fill) ?? parent.fill,
-      fillRule: fillRule,
+      fillRule: fillRule ?? parent.fillRule,
       clipRule: clipRule ?? parent.clipRule,
       clipPathId: clipPathId ?? parent.clipPathId,
       blendMode: blendMode ?? parent.blendMode,

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -1660,8 +1660,7 @@ class SvgParser {
           color,
           id,
         ),
-        fillRule:
-            parseRawFillRule(attributeMap['fill-rule']),
+        fillRule: parseRawFillRule(attributeMap['fill-rule']),
         clipRule: parseRawFillRule(attributeMap['clip-rule']),
         clipPathId: attributeMap['clip-path'],
         blendMode: _blendModes[attributeMap['mix-blend-mode']],

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -90,7 +90,9 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
     final AffineMatrix transform = data.multiplied(
       pathNode.attributes.transform,
     );
-    final Path transformedPath = pathNode.path.transformed(transform);
+    final Path transformedPath = pathNode.path
+        .transformed(transform)
+        .withFillType(pathNode.attributes.fillRule ?? pathNode.path.fillType);
     final Rect originalBounds = pathNode.path.bounds();
     final Rect newBounds = transformedPath.bounds();
     final Paint? paint = pathNode.computePaint(originalBounds, transform);

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,46 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Fill rule inheritence', () {
+    final VectorInstructions instructions =
+        parseWithoutOptimizers(inheritFillRule);
+
+    expect(instructions.paints, const <Paint>[
+      Paint(
+        blendMode: BlendMode.srcOver,
+        stroke: Stroke(color: Color(0xffff0000)),
+        fill: Fill(color: Color(0xff000000)),
+      ),
+    ]);
+    expect(instructions.paths, <Path>[
+      Path(
+        commands: const <PathCommand>[
+          MoveToCommand(60.0, 10.0),
+          LineToCommand(31.0, 100.0),
+          LineToCommand(108.0, 45.0),
+          LineToCommand(12.0, 45.0),
+          LineToCommand(89.0, 100.0),
+          CloseCommand()
+        ],
+      ),
+      Path(
+        commands: const <PathCommand>[
+          MoveToCommand(160.0, 10.0),
+          LineToCommand(131.0, 100.0),
+          LineToCommand(208.0, 45.0),
+          LineToCommand(112.0, 45.0),
+          LineToCommand(189.0, 100.0),
+          CloseCommand()
+        ],
+        fillType: PathFillType.evenOdd,
+      )
+    ]);
+    expect(instructions.commands, const <DrawCommand>[
+      DrawCommand(DrawCommandType.path, objectId: 0, paintId: 0),
+      DrawCommand(DrawCommandType.path, objectId: 1, paintId: 0),
+    ]);
+  });
+
   test('Text whitespace handling (number bubbles)', () {
     final VectorInstructions instructions =
         parseWithoutOptimizers(numberBubbles);
@@ -139,7 +179,7 @@ void main() {
 
   test('stroke-opacity', () {
     const String strokeOpacitySvg = '''
-<svg viewBox="0 0 10 10">
+<svg viewBox="0 0 10 10" fill="none">
   <rect x="0" y="0" width="5" height="5" stroke="red" stroke-opacity=".5" />
 </svg>
 ''';

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -27,7 +27,7 @@ const String kBase64ImageContents =
 
 /// https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/svg.svg
 const String useStar = '''
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" fill="none">
  <g id='gtop' stroke-width="12" stroke="#000">
    <g id="svgstar" transform="translate(50,50)">
      <path id="svgbar" d="M-27-5a7,7,0,1,0,0,10h54a7,7,0,1,0,0-10z"/>
@@ -1396,7 +1396,7 @@ List<Path> basicClipsForClippingOptimzer = <Path>[
 
 /// https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/bzrfeed.svg
 const String signWithScaledStroke = '''
-<svg xmlns="http://www.w3.org/2000/svg" stroke-linejoin="round" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" stroke-linejoin="round" viewBox="0 0 100 100" fill="none">
   <path d="M50,4L4,50L50,96L96,50Z" stroke="#FE4" stroke-width="3"/>
   <path d="M50,5L5,50L50,95L95,50Z" stroke="#333" fill="#FE4" stroke-width="3"/>
   <g transform="scale(0.8) translate(14,30)">
@@ -1456,4 +1456,27 @@ const String numberBubbles = '''
                 </text>
     </g>
 </svg>
+''';
+
+/// Via https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule
+const String inheritFillRule = '''
+<svg viewBox="-10 -10 220 120" xmlns="http://www.w3.org/2000/svg">
+  <!-- Default value for fill-rule -->
+  <polygon
+    fill-rule="nonzero"
+    stroke="red"
+    points="50,0 21,90 98,35 2,35 79,90" />
+
+  <!--
+  The center of the shape has two
+  path segments (shown by the red stroke)
+  between it and infinity. It is therefore
+  considered outside the shape, and not filled.
+  -->
+  <polygon
+    fill-rule="evenodd"
+    stroke="red"
+    points="150,0 121,90 198,35 102,35 179,90" />
+</svg>
+
 ''';


### PR DESCRIPTION
Fixes https://github.com/dnfield/flutter_svg/issues/876

While working on that, noticed that default fills weren't getting set correctly and fixed that as well.

While looking at that, I started thinking we might want to make `Path` const constructible. But that is a slightly bigger change especially since it'd probably mean changing the way `addPath` works to avoid mutating the underlying path command list, so I'll leave it for some other time.