### PR TITLE
Support more image formats, be more tolerant of badly formed MIME types

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.4
+
+- Support more image formats and malformed MIME types.
+- Fix inheritence for `fill-rule`s.
+
 ## 1.1.3
 
 - Further improvements to whitespace handling for text.

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics
 description: A vector graphics rendering package for Flutter.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/dnfield/vector_graphics
 
 environment:
@@ -10,13 +10,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_graphics_codec: 1.1.3
+  vector_graphics_codec: 1.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.0
-  vector_graphics_compiler: 1.1.3
+  vector_graphics_compiler: 1.1.4
 
 # Comment out before publishing
 dependency_overrides:

--- a/packages/vector_graphics_codec/CHANGELOG.md
+++ b/packages/vector_graphics_codec/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.4
+
+- Support more image formats and malformed MIME types.
+- Fix inheritence for `fill-rule`s.
+
 ## 1.1.3
 
 - Further improvements to whitespace handling for text.

--- a/packages/vector_graphics_codec/pubspec.yaml
+++ b/packages/vector_graphics_codec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics_codec
 description: An encoding library for `package:vector_graphics`
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/dnfield/vector_graphics
 
 environment:

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.4
+
+- Support more image formats and malformed MIME types.
+- Fix inheritence for `fill-rule`s.
+
 ## 1.1.3
 
 - Further improvements to whitespace handling for text.

--- a/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
+++ b/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
@@ -129,7 +129,7 @@ class DrawCommandBuilder {
 
   /// Add an image to the current draw command stack.
   void addImage(ResolvedImageNode node, String? debugString) {
-    final ImageData imageData = ImageData(node.data, 0);
+    final ImageData imageData = ImageData(node.data, node.format.index);
     final int imageId = _getOrGenerateId(imageData, _images);
     final DrawImageData drawImageData = DrawImageData(
       imageId,

--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import '../geometry/basic_types.dart';
 import '../geometry/matrix.dart';
 import '../geometry/path.dart';
+import '../image/image_info.dart';
 import '../paint.dart';
 import 'parser.dart' show SvgAttributes;
 import 'visitor.dart';
@@ -571,11 +572,15 @@ class ImageNode extends AttributedNode {
   /// Create a new [ImageNode] with the given [text].
   ImageNode(
     this.data,
+    this.format,
     super.attributes,
   );
 
-  /// The text this node contains.
+  /// The image data this node contains.
   final Uint8List data;
+
+  /// The format of [data].
+  final ImageFormat format;
 
   @override
   AttributedNode applyAttributes(
@@ -584,6 +589,7 @@ class ImageNode extends AttributedNode {
   }) {
     return ImageNode(
       data,
+      format,
       replace
           ? newAttributes.applyParent(attributes, transformOverride: transform)
           : attributes.applyParent(newAttributes),

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -264,6 +264,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
       // trivial transform.
       return ResolvedImageNode(
         data: imageNode.data,
+        format: imageNode.format,
         rect: childTransform.transformRect(rect),
         transform: null,
       );
@@ -272,6 +273,7 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
     // Non-trivial transform.
     return ResolvedImageNode(
       data: imageNode.data,
+      format: imageNode.format,
       rect: rect,
       transform: childTransform,
     );
@@ -483,12 +485,16 @@ class ResolvedImageNode extends Node {
   /// Create a new [ResolvedImageNode].
   const ResolvedImageNode({
     required this.data,
+    required this.format,
     required this.rect,
     required this.transform,
   });
 
   /// The image [data] encoded as a PNG.
   final Uint8List data;
+
+  /// The format of [data].
+  final ImageFormat format;
 
   /// The region to draw the image to.
   final Rect rect;

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics_compiler
 description: A compiler for `package:vector_graphics`.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/dnfield/vector_graphics
 
 executables:
@@ -14,7 +14,7 @@ dependencies:
   meta: ^1.7.0
   path_parsing: ^1.0.1
   xml: ^6.0.1
-  vector_graphics_codec: 1.1.3
+  vector_graphics_codec: 1.1.4
 
 dev_dependencies:
   flutter_lints: ^1.0.0
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  vector_graphics: 1.1.3
+  vector_graphics: 1.1.4
 
 # Comment out before publishing
 dependency_overrides:

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -1321,6 +1321,24 @@ void main() {
     expect(instructions.drawImages.first.rect, const Rect.fromLTWH(0, 0, 1, 1));
   });
 
+  test('Other image formats', () {
+    // 1x1 PNG image from png-pixel.com. Claiming that it's JPEG and using "img"
+    // instead of "image" to make sure parser doesn't barf. Chrome is ok with
+    // this kind of nonsense. How far we have strayed.
+    const String svgStr = '''
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <image href="data:img/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==" />
+</svg>''';
+
+    final VectorInstructions instructions = parseWithoutOptimizers(
+      svgStr,
+      key: 'image',
+      warningsAsErrors: true,
+    );
+
+    expect(instructions.images.first.format, 1);
+  });
+
   test('Ghostscript Tiger - dedupes paints', () {
     final VectorInstructions instructions = parseWithoutOptimizers(
       ghostscriptTiger,


### PR DESCRIPTION
The mime type might lie, or be malformed.In the end Flutter will render it as long as it's a supported image type at runtime.

fixes https://github.com/dnfield/flutter_svg/issues/884 