### PR TITLE
Fix text positioning when transform but no x/y or dx/dy

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/node.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/node.dart
@@ -250,12 +250,18 @@ class TextPositionNode extends ParentNode {
   /// Computes a [TextPosition] to encode for this node.
   TextPosition computeTextPosition(Rect bounds, AffineMatrix transform) {
     final AffineMatrix computedTransform = concatTransform(transform);
-    final bool consumeTransform = computedTransform.encodableInRect;
+
     double? x = attributes.x?.calculate(bounds.width);
     double? y = attributes.y?.calculate(bounds.height);
     double? dx = attributes.dx?.calculate(bounds.width);
     double? dy = attributes.dy?.calculate(bounds.height);
-    if (x != null && y != null) {
+
+    final bool hasXY = x != null && y != null;
+    final bool hasDxDy = dx != null && dy != null;
+    final bool consumeTransform =
+        computedTransform.encodableInRect && (hasXY || hasDxDy);
+
+    if (hasXY) {
       final Point baseline = consumeTransform
           ? transform.transformPoint(Point(x, y))
           : Point(x, y);
@@ -263,7 +269,7 @@ class TextPositionNode extends ParentNode {
       y = baseline.y;
     }
 
-    if (dx != null && dy != null) {
+    if (hasDxDy) {
       final Point baseline = consumeTransform
           ? transform.transformPoint(Point(dx, dy))
           : Point(dx, dy);

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,45 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Text transform but no xy', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<svg viewBox="0 0 450 150" xmlns="http://www.w3.org/2000/svg">
+  <g fill="red" font-family="Arimo,Liberation Sans,HammersmithOne,Helvetica,Arial,sans-serif"
+    font-weight="600">
+    <text font-size="40" transform="translate(60 45)">東急電鉄路線図</text>
+    <text font-size="22" transform="translate(60 75)">Tōkyū Railways route map</text>
+  </g>
+</svg>
+''');
+
+    expect(instructions.text, const <TextConfig>[
+      TextConfig(
+        '東急電鉄路線図',
+        0.0,
+        'Arimo,Liberation Sans,HammersmithOne,Helvetica,Arial,sans-serif',
+        FontWeight.w600,
+        40.0,
+        TextDecoration.none,
+        TextDecorationStyle.solid,
+        Color(0xff000000),
+      ),
+      TextConfig(
+        'Tōkyū Railways route map',
+        0.0,
+        'Arimo,Liberation Sans,HammersmithOne,Helvetica,Arial,sans-serif',
+        FontWeight.w600,
+        22.0,
+        TextDecoration.none,
+        TextDecorationStyle.solid,
+        Color(0xff000000),
+      ),
+    ]);
+    expect(instructions.textPositions, <TextPosition>[
+      TextPosition(reset: true, transform: AffineMatrix.identity.translated(60, 45)),
+      TextPosition(reset: true, transform: AffineMatrix.identity.translated(60, 75)),
+    ]);
+  });
+
   test('Fill rule inheritence', () {
     final VectorInstructions instructions =
         parseWithoutOptimizers(inheritFillRule);


### PR DESCRIPTION
Before this patch we were sometimes dropping the transform if it was encodable into the points but the points were not set.

Fixes https://github.com/dnfield/vector_graphics/issues/199#issuecomment-1505578718