### PR TITLE
- fixed bug of Unhandled Exception: Null check operator used on a nul…

### DIFF
--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -205,7 +205,7 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     TextDirection? textDirection,
     bool clipViewbox = true,
     @visibleForTesting
-        PictureFactory pictureFactory = const _DefaultPictureFactory(),
+    PictureFactory pictureFactory = const _DefaultPictureFactory(),
     VectorGraphicsErrorListener? onError,
   }) {
     final PictureRecorder recorder = pictureFactory.createPictureRecorder();

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -193,8 +193,8 @@ class _Elements {
 
   static void use(SvgParser parserState, bool warningsAsErrors) {
     final ParentNode? parent = parserState.currentGroup;
-    final String xlinkHref = parserState._currentAttributes.href!;
-    if (xlinkHref.isEmpty) {
+    final String? xlinkHref = parserState._currentAttributes.href;
+    if (xlinkHref == null || xlinkHref.isEmpty) {
       return;
     }
 

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -1262,6 +1262,45 @@ void main() {
     );
   });
 
+  test('Use circles test without href', () {
+    final VectorInstructions instructions = parseWithoutOptimizers(
+      simpleUseCirclesWithoutHref,
+      key: 'useCirclesWithoutHref',
+      warningsAsErrors: true,
+    );
+
+    expect(instructions.paints, const <Paint>[
+      Paint(
+        stroke: Stroke(color: Color(0xff0000ff)),
+        fill: Fill(color: Color(0xff000000)),
+      ),
+    ]);
+
+    expect(instructions.paths, <Path>[
+      Path(
+        commands: const <PathCommand>[
+          MoveToCommand(5.0, 1.0),
+          CubicToCommand(
+              7.2076600979759995, 1.0, 9.0, 2.792339902024, 9.0, 5.0),
+          CubicToCommand(
+              9.0, 7.2076600979759995, 7.2076600979759995, 9.0, 5.0, 9.0),
+          CubicToCommand(
+              2.792339902024, 9.0, 1.0, 7.2076600979759995, 1.0, 5.0),
+          CubicToCommand(1.0, 2.792339902024, 2.792339902024, 1.0, 5.0, 1.0),
+          CloseCommand()
+        ],
+      ),
+    ]);
+
+    expect(
+      instructions.commands,
+      const <DrawCommand>[
+        DrawCommand(DrawCommandType.path,
+            objectId: 0, paintId: 0, debugString: 'myCircle'),
+      ],
+    );
+  });
+
   test('Parses pattern used as fill and stroke', () {
     final VectorInstructions instructions = parseWithoutOptimizers(
       starPatternCircles,

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -1271,7 +1271,6 @@ void main() {
 
     expect(instructions.paints, const <Paint>[
       Paint(
-        stroke: Stroke(color: Color(0xff0000ff)),
         fill: Fill(color: Color(0xff000000)),
       ),
     ]);

--- a/packages/vector_graphics_compiler/test/test_svg_strings.dart
+++ b/packages/vector_graphics_compiler/test/test_svg_strings.dart
@@ -938,6 +938,15 @@ const String simpleUseCirclesOoO = '''
 </svg>
 ''';
 
+const String simpleUseCirclesWithoutHref = '''
+<svg viewBox="0 0 30 10"
+    xmlns="http://www.w3.org/2000/svg">
+    <circle id="myCircle" cx="5" cy="5" r="4"/>
+    <use x="10" fill="blue"/>
+    <use x="20" fill="white" stroke="blue"/>
+</svg>
+''';
+
 /// https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
 const String basicText = '''
 <svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
I've found a bug in your code, when trying to parse this SVG flag by using flutter_svg (you can use it to test the error) : 
[https://github.com/lipis/flag-icons/blob/main/flags/1x1/bo.svg](https://github.com/lipis/flag-icons/blob/main/flags/1x1/bo.svg)

When I tried to open the SVG in my app by using the SvgPicture.asset , this error has appeared : 

E/flutter ( 5921): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Null check operator used on a null value
E/flutter ( 5921): #0      _Elements.use
parser.dart:196
E/flutter ( 5921): #1      SvgParser._parseTree
parser.dart:777
E/flutter ( 5921): #2      SvgParser.parse
parser.dart:797
E/flutter ( 5921): #3      parse
vector_graphics_compiler.dart:76
E/flutter ( 5921): #4      encodeSvg
vector_graphics_compiler.dart:143
E/flutter ( 5921): #5      SvgLoader._load.<anonymous closure>.<anonymous closure>
loaders.dart:137
E/flutter ( 5921): #6      _testCompute
compute.dart:12
E/flutter ( 5921): #7      SvgLoader._load.<anonymous closure>
loaders.dart:135

A similar error happened when trying to precompiling and optimizing this same SVG.

So, I did a simple and small change to the code and tested it directly in my app with the same SVG, and it happened to be working again. Just did a small check to see if href is null. I've put it in a way which doesn't change the code's functionality.

I hope that I've helped you guys out a little bit =)