### PR TITLE
Export `Render*VectorGraphic`

### DIFF
--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/html_render_vector_graphics.dart' show RenderWebVectorGraphic;
+export 'src/render_vector_graphics.dart' show RenderVectorGraphic;
 export 'src/vector_graphics.dart'
     show
         AssetBytesLoader,

--- a/packages/vector_graphics/lib/vector_graphics_compat.dart
+++ b/packages/vector_graphics/lib/vector_graphics_compat.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/html_render_vector_graphics.dart' show RenderWebVectorGraphic;
+export 'src/render_vector_graphics.dart' show RenderVectorGraphic;
 export 'src/vector_graphics.dart'
     show
         AssetBytesLoader,


### PR DESCRIPTION
So that we can reuse them (directly without `import src/xx`) in customized render boxes.