### PR TITLE
Improve the unhandled element error message a little.

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -939,7 +939,7 @@ class SvgParser {
   /// `<style/>`, `<title/>`, and `<desc/>` elements.
   void unhandledElement(XmlStartElementEvent event) {
     final String errorMessage =
-        'unhandled element ${event.name}; Picture key: $_key';
+        'unhandled element <${event.name}/>; Picture key: $_key';
     if (_warningsAsErrors) {
       // Throw error instead of log warning.
       throw UnimplementedError(errorMessage);


### PR DESCRIPTION
I spent ~5 minutes not understanding what about the SVG styles were wrong, to only eventually realise it was the <style> tag that it didn't like. Minor tweak, but I suspect it'll save the next person 5 minutes.