### PR TITLE
Avoid stack overflow when self-referential elemetns present, only use…

### DIFF
--- a/packages/vector_graphics/CHANGELOG.md
+++ b/packages/vector_graphics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.1.9
+
+- Fix handling of invalid XML `@id` attributes.
+- Fix handling of self-referential `<use/>` elements.
+- Add `--out-dir` option to compiler.
+- Tweak warning message for unhandled eleemnts.
+
 ## 1.1.8
 
 -  Fix bugs in transform parsing.

--- a/packages/vector_graphics/pubspec.yaml
+++ b/packages/vector_graphics/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics
 description: A vector graphics rendering package for Flutter.
-version: 1.1.8
+version: 1.1.9
 homepage: https://github.com/dnfield/vector_graphics
 
 environment:
@@ -10,13 +10,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_graphics_codec: 1.1.8
+  vector_graphics_codec: 1.1.9
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.0
-  vector_graphics_compiler: 1.1.8
+  vector_graphics_compiler: 1.1.9
 
 # Comment out before publishing
 dependency_overrides:

--- a/packages/vector_graphics_codec/CHANGELOG.md
+++ b/packages/vector_graphics_codec/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.1.9
+
+- Fix handling of invalid XML `@id` attributes.
+- Fix handling of self-referential `<use/>` elements.
+- Add `--out-dir` option to compiler.
+- Tweak warning message for unhandled eleemnts.
+
 ## 1.1.8
 
 -  Fix bugs in transform parsing.

--- a/packages/vector_graphics_codec/pubspec.yaml
+++ b/packages/vector_graphics_codec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics_codec
 description: An encoding library for `package:vector_graphics`
-version: 1.1.8
+version: 1.1.9
 homepage: https://github.com/dnfield/vector_graphics
 
 environment:

--- a/packages/vector_graphics_compiler/CHANGELOG.md
+++ b/packages/vector_graphics_compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.1.9
+
+- Fix handling of invalid XML `@id` attributes.
+- Fix handling of self-referential `<use/>` elements.
+- Add `--out-dir` option to compiler.
+- Tweak warning message for unhandled eleemnts.
+
 ## 1.1.8
 
 -  Fix bugs in transform parsing.

--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -226,7 +226,9 @@ class _Elements {
       maskResolver: parserState._definitions.getDrawable,
       patternResolver: parserState._definitions.getDrawable,
     );
-    parserState.checkForIri(group);
+    if ('#${parserState._currentAttributes.id}' != xlinkHref) {
+      parserState.checkForIri(group);
+    }
     parent!.addChild(
       group,
       clipId: parserState._currentAttributes.clipPathId,
@@ -864,10 +866,11 @@ class SvgParser {
   }
 
   /// Whether this [DrawableStyleable] belongs in the [DrawableDefinitions] or not.
-  bool checkForIri(AttributedNode? drawable) {
+  bool checkForIri(AttributedNode drawable) {
+    assert('#${_currentAttributes.id}' != _currentAttributes.href);
     final String iri = buildUrlIri();
     if (iri != emptyUrlIri) {
-      _definitions.addDrawable(iri, drawable!);
+      _definitions.addDrawable(iri, drawable);
       return true;
     }
     return false;
@@ -1797,6 +1800,9 @@ class _Resolver {
     String? href,
   ) {
     assert(!_sealed);
+    if (_shaders.containsKey(gradient.id)) {
+      return;
+    }
     _shaders[gradient.id] = gradient;
     if (href != null) {
       href = 'url($href)';
@@ -1820,13 +1826,13 @@ class _Resolver {
   /// Add the clip defined by [pathNodes] to the resolver identifier by [ref].
   void addClipPath(String ref, List<Node> pathNodes) {
     assert(!_sealed);
-    _clips[ref] = pathNodes;
+    _clips.putIfAbsent(ref, () => pathNodes);
   }
 
   /// Add the [drawable] to the resolver identifier by [ref].
   void addDrawable(String ref, AttributedNode drawable) {
     assert(!_sealed);
-    _drawables[ref] = drawable;
+    _drawables.putIfAbsent(ref, () => drawable);
   }
 }
 

--- a/packages/vector_graphics_compiler/pubspec.yaml
+++ b/packages/vector_graphics_compiler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_graphics_compiler
 description: A compiler for `package:vector_graphics`.
-version: 1.1.8
+version: 1.1.9
 homepage: https://github.com/dnfield/vector_graphics
 
 executables:
@@ -14,7 +14,7 @@ dependencies:
   meta: ^1.7.0
   path_parsing: ^1.0.1
   xml: ^6.3.0
-  vector_graphics_codec: 1.1.8
+  vector_graphics_codec: 1.1.9
   path: ^1.8.0
 
 dev_dependencies:
@@ -25,7 +25,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  vector_graphics: 1.1.8
+  vector_graphics: 1.1.9
 
 # Comment out before publishing
 dependency_overrides:

--- a/packages/vector_graphics_compiler/test/parser_test.dart
+++ b/packages/vector_graphics_compiler/test/parser_test.dart
@@ -4,6 +4,31 @@ import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 import 'test_svg_strings.dart';
 
 void main() {
+  test('Reuse ID self-referentially', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <rect x="2" y="2" width="20" height="20" id="path-1"/>
+  </defs>
+  <use id="path-1" fill="#FFFFFF" xlink:href="#path-1"/>
+</svg>
+''');
+
+    expect(instructions.paths.length, 1);
+  });
+
+  test('Self-referentially ID', () {
+    final VectorInstructions instructions = parseWithoutOptimizers('''
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <use id="path-1" fill="#FFFFFF" xlink:href="#path-1"/>
+</svg>
+''');
+
+    expect(instructions.paths.length, 0);
+  });
+
   test('Text transform but no xy', () {
     final VectorInstructions instructions = parseWithoutOptimizers('''
 <svg viewBox="0 0 450 150" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
… first ID

- The XML specification says that the `id` attribute must be unique per document. However, SVGs in the wild don't necessarily do this. Browsers seem to handle this by taking the _first_ instance of an ID and ignoring subsequent ones. This patch changes behavior so that only the first `id` is used instead of the last one.
- A `use` element that tries to use itself doesn't make sense. This patch detects when a `use` element tries to use itself and ignores that, which prevents a later stack overflow issue.

Fixes https://github.com/dnfield/flutter_svg/issues/997