### PR TITLE
Fix parsing transforms with scientific notation

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parsers.dart
@@ -29,23 +29,26 @@ List<double> _parseTransformParams(String params) {
   final List<double> result = <double>[];
   String current = '';
   for (int i = 0; i < params.length; i += 1) {
-    if (params[i] == ' ' || params[i] == '-' || params[i] == ',') {
+    final String char = params[i];
+    final bool isSeparator = char == ' ' || char == '-' || char == ',';
+    final bool isExponent = i > 0 && params[i - 1] == 'e';
+    if (isSeparator && !isExponent) {
       if (current != '') {
         result.add(parseDouble(current)!);
       }
-      if (params[i] == '-') {
+      if (char == '-') {
         current = '-';
       } else {
         current = '';
       }
     } else {
-      if (params[i] == '.') {
+      if (char == '.') {
         if (current.contains('.')) {
           result.add(parseDouble(current)!);
           current = '';
         }
       }
-      current += params[i];
+      current += char;
     }
   }
   if (current.isNotEmpty) {

--- a/packages/vector_graphics_compiler/test/parsers_test.dart
+++ b/packages/vector_graphics_compiler/test/parsers_test.dart
@@ -173,6 +173,13 @@ void main() {
     expect(parseDoubleWithUnits('1pt', theme: const SvgTheme()), 1 + 1 / 3);
   });
 
+  test('Parse a transform with scientific notation', () {
+    expect(
+      parseTransform('translate(9e-6,6.5e-4)'),
+      AffineMatrix.identity.translated(9e-6, 6.5e-4),
+    );
+  });
+
   test('Parse a transform with a missing space', () {
     expect(
       parseTransform('translate(0-70)'),


### PR DESCRIPTION
#208 seems to have introduced a bug that prevents parsing transforms with scientific notation in its values. This has also propagated to https://github.com/dnfield/flutter_svg/issues/998.

To mitigate this, it looks to me like simply ignoring separator characters right after an `"e"` character works. I've included a test to verify this.

The variable `char` was only added for code quality, as the `final bool isSeparator = ...` line was running too long otherwise, causing a like break to be introduced by the formatter.

Fixes https://github.com/dnfield/flutter_svg/issues/998