### PR TITLE
Apply a clip rectangle if a color filter is used

### DIFF
--- a/packages/vector_graphics/lib/src/render_vector_graphic.dart
+++ b/packages/vector_graphics/lib/src/render_vector_graphic.dart
@@ -439,6 +439,7 @@ class RenderPictureVectorGraphic extends RenderBox {
       context.canvas.translate(offset.dx, offset.dy);
     }
     if (_opacityValue != 1.0 || colorFilter != null) {
+      context.canvas.clipRect(Offset.zero & size);
       context.canvas.saveLayer(Offset.zero & size, colorPaint);
     }
     context.canvas.drawPicture(pictureInfo.picture);

--- a/packages/vector_graphics/test/render_vector_graphics_test.dart
+++ b/packages/vector_graphics/test/render_vector_graphics_test.dart
@@ -408,6 +408,20 @@ void main() {
 
     expect(data.dispose, returnsNormally);
   });
+
+  test('Color filter applies clip', () async {
+    final RenderPictureVectorGraphic render = RenderPictureVectorGraphic(
+      pictureInfo,
+      const ui.ColorFilter.mode(Colors.green, ui.BlendMode.difference),
+      null,
+    );
+    render.layout(BoxConstraints.tight(const Size(50, 50)));
+    final FakePaintingContext context = FakePaintingContext();
+    render.paint(context, Offset.zero);
+
+    expect(context.canvas.lastClipRect,
+        equals(const ui.Rect.fromLTRB(0, 0, 50, 50)));
+  });
 }
 
 class FakeCanvas extends Fake implements Canvas {
@@ -415,6 +429,7 @@ class FakeCanvas extends Fake implements Canvas {
   Rect? lastSrc;
   Rect? lastDst;
   Paint? lastPaint;
+  Rect? lastClipRect;
 
   @override
   void drawImageRect(ui.Image image, Rect src, Rect dst, Paint paint) {
@@ -422,6 +437,26 @@ class FakeCanvas extends Fake implements Canvas {
     lastSrc = src;
     lastDst = dst;
     lastPaint = paint;
+  }
+
+  @override
+  void drawPicture(ui.Picture picture) {}
+
+  @override
+  int getSaveCount() {
+    return 0;
+  }
+
+  @override
+  void restoreToCount(int count) {}
+
+  @override
+  void saveLayer(Rect? bounds, Paint paint) {}
+
+  @override
+  void clipRect(ui.Rect rect,
+      {ui.ClipOp clipOp = ui.ClipOp.intersect, bool doAntiAlias = true}) {
+    lastClipRect = rect;
   }
 }
 


### PR DESCRIPTION
Skia's SkCanvas::saveLayer does not implicitly clip to the bounds rect.

See https://github.com/flutter/flutter/issues/142620