### PR TITLE
Add support for animated transitions between the various loading states

### DIFF
--- a/packages/vector_graphics/example/lib/main.dart
+++ b/packages/vector_graphics/example/lib/main.dart
@@ -24,10 +24,22 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const Scaffold(
+      home: Scaffold(
         body: Center(
           child: VectorGraphic(
-            loader: NetworkSvgLoader(
+            placeholderBuilder: (BuildContext context) => Container(
+                color: Colors.green,
+                width: double.infinity,
+                height: double.infinity,
+                child: const Center(
+                  child: SizedBox(
+                    width: 25,
+                    height: 25,
+                    child: CircularProgressIndicator(),
+                  ),
+                )),
+            transitionConfig: const VectorGraphicsStateTransitionConfig(),
+            loader: const NetworkSvgLoader(
               'https://upload.wikimedia.org/wikipedia/commons/f/fd/Ghostscript_Tiger.svg',
             ),
           ),

--- a/packages/vector_graphics/lib/src/state_transition_config.dart
+++ b/packages/vector_graphics/lib/src/state_transition_config.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// The configuration of transition animation between loading/loaded states
+///
+/// Containing all parameters supported by the [AnimatedSwitcher] widget which is
+/// used for the animation.
+class VectorGraphicsStateTransitionConfig {
+
+  /// Creates a [VectorGraphicsStateTransitionConfig] with the given parameters.
+  ///
+  /// All parameters are optional and have default values to simplify usage.
+  const VectorGraphicsStateTransitionConfig({
+    this.duration = const Duration(milliseconds: 400),
+    this.reverseDuration,
+    this.switchInCurve = Curves.linear,
+    this.switchOutCurve = Curves.linear,
+    this.transitionBuilder = AnimatedSwitcher.defaultTransitionBuilder,
+    this.layoutBuilder = AnimatedSwitcher.defaultLayoutBuilder,
+  });
+
+  /// The duration of the transition from one state to the next.
+  ///
+  /// Defaults to 400 milliseconds.
+  final Duration duration;
+
+  /// The duration of the reverse transition from the next state to the previous one.
+  final Duration? reverseDuration;
+
+  /// The curve to apply when transitioning in.
+  ///
+  /// Defaults to [Curves.linear].
+  final Curve switchInCurve;
+
+  /// The curve to apply when transitioning out.
+  ///
+  /// Defaults to [Curves.linear].
+  final Curve switchOutCurve;
+
+  /// The builder for constructing the transition animations.
+  ///
+  /// Defaults to [AnimatedSwitcher.defaultTransitionBuilder].
+  final AnimatedSwitcherTransitionBuilder transitionBuilder;
+
+  /// The builder for laying out the child widgets during the transition.
+  ///
+  /// Defaults to [AnimatedSwitcher.defaultLayoutBuilder].
+  final AnimatedSwitcherLayoutBuilder layoutBuilder;
+}

--- a/packages/vector_graphics/lib/vector_graphics.dart
+++ b/packages/vector_graphics/lib/vector_graphics.dart
@@ -10,4 +10,5 @@ export 'src/vector_graphics.dart'
         BytesLoader,
         VectorGraphic,
         VectorGraphicUtilities,
+        VectorGraphicsStateTransitionConfig,
         vg;

--- a/packages/vector_graphics/lib/vector_graphics_compat.dart
+++ b/packages/vector_graphics/lib/vector_graphics_compat.dart
@@ -10,6 +10,7 @@ export 'src/vector_graphics.dart'
         BytesLoader,
         VectorGraphic,
         VectorGraphicUtilities,
+        VectorGraphicsStateTransitionConfig,
         vg,
         RenderingStrategy,
         createCompatVectorGraphic;


### PR DESCRIPTION
This attempts to resolve #193 .

Adds a transition configuration object that when provided will be used to animate between states (e.g placeholder to loaded/error state). If omitted there's no animation. Values in the configuration are just forwarded to the `AnimatedSwitcher` widget which does the animation.