### PR TITLE
fix-null-exception

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/parser.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/parser.dart
@@ -889,7 +889,10 @@ class SvgParser {
       return false;
     }
     final ParentNode parent = _parentDrawables.last.drawable;
-    final Path path = pathFunc(this)!;
+    final Path? path = pathFunc(this);
+    if (path == null) {
+      return false;
+    }
     final PathNode drawable = PathNode(path, _currentAttributes);
     checkForIri(drawable);
 


### PR DESCRIPTION
The following SVG throw an exception (when using flutter_svg) : https://sweden.a.bigcontent.io/v1/static/10000199.

This SVG contain an empty <polygon> tag : `<polygon xmlns="http://www.w3.org/2000/svg" fill="#0a287d" points="" id="polygon7"/>` which lead to the issue.

Checking as this PR did if path is null avoid the issue.