### PR TITLE
feat: remove unnecessary 'tryParse' on parseDouble

### DIFF
--- a/packages/vector_graphics_compiler/lib/src/svg/numbers.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/numbers.dart
@@ -12,8 +12,7 @@ import 'theme.dart';
 /// which is stripped off when parsed to a `double`.
 ///
 /// Passing `null` will return `null`.
-double? parseDouble(String? rawDouble, {bool tryParse = false}) {
-  assert(tryParse != null); // ignore: unnecessary_null_comparison
+double? parseDouble(String? rawDouble) {
   if (rawDouble == null) {
     return null;
   }
@@ -26,10 +25,7 @@ double? parseDouble(String? rawDouble, {bool tryParse = false}) {
       .replaceFirst('pt', '')
       .trim();
 
-  if (tryParse) {
-    return double.tryParse(rawDouble);
-  }
-  return double.parse(rawDouble);
+  return double.tryParse(rawDouble);
 }
 
 /// Convert [degrees] to radians.
@@ -81,7 +77,6 @@ double? parseDoubleWithUnits(
   }
   final double? value = parseDouble(
     rawDouble,
-    tryParse: tryParse,
   );
 
   return value != null ? value * unit : null;


### PR DESCRIPTION
There is some issue while calling parseDouble like this: https://github.com/dnfield/vector_graphics/issues/209
I suggest a fix to change the return of **parseDouble** to always double.tryParse so that it will return `null` instead of throwing an error if it parses an invalid String